### PR TITLE
Various Usability Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+script:
+  - cargo test --all

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Etcommon
 
+[![Build Status](https://travis-ci.org/ethereumproject/etcommon-rs.svg?branch=master)](https://travis-ci.org/ethereumproject/etcommon-rs)
+
 Apache-2 licensed common Ethereum structs shared by crates. Work-in-progress right now.
 
 ## Rolling Release

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -11,8 +11,8 @@ heapsize = "0.4"
 byteorder = "1.0"
 rand = "0.3.12"
 libc = "0.2"
-etcommon-rlp = { path = '../rlp' }
-etcommon-util = { path = '../util' }
+etcommon-rlp = "0.1.1"
+etcommon-util = "0.1.0"
 
 [features]
 x64asm_arithmetic=[]

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-bigint"
-version = "0.1.8"
+version = "0.1.9"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Big integer (256-bit and 512-bit) implementation for SputnikVM and other Ethereum Classic clients."

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-bigint"
-version = "0.1.7"
+version = "0.1.8"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Big integer (256-bit and 512-bit) implementation for SputnikVM and other Ethereum Classic clients."

--- a/bigint/src/m256.rs
+++ b/bigint/src/m256.rs
@@ -60,6 +60,15 @@ impl M256 {
     pub fn byte(&self, index: usize) -> u8 {
         self.0.byte(index)
     }
+    /// Return specific byte in big-endian format.
+    ///
+	/// # Panics
+	///
+	/// Panics if `index` exceeds the byte width of the number.
+    #[inline]
+    pub fn index(&self, index: usize) -> u8 {
+        self.0.index(index)
+    }
 }
 
 impl Default for M256 { fn default() -> M256 { M256::zero() } }

--- a/bigint/src/uint/mod.rs
+++ b/bigint/src/uint/mod.rs
@@ -31,7 +31,7 @@
 
 use std::{fmt, cmp};
 use std::str::{FromStr};
-use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub};
+use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub, Index};
 use std::cmp::Ordering;
 use byteorder::{ByteOrder, BigEndian, LittleEndian};
 use util::{ParseHexError, read_hex};
@@ -603,17 +603,27 @@ macro_rules! construct_uint {
 				arr[index / 64] & (1 << (index % 64)) != 0
 			}
 
-			/// Return specific byte. This is in the big endian format.
+			/// Return specific byte.
 			///
 			/// # Panics
 			///
 			/// Panics if `index` exceeds the byte width of the number.
 			#[inline]
 			pub fn byte(&self, index: usize) -> u8 {
-			    let index = $n_words * 8 - 1 - index;
 				let &$name(ref arr) = self;
 				(arr[index / 8] >> (((index % 8)) * 8)) as u8
 			}
+
+            /// Return specific byte in big-endian format.
+            ///
+			/// # Panics
+			///
+			/// Panics if `index` exceeds the byte width of the number.
+            #[inline]
+            pub fn index(&self, index: usize) -> u8 {
+                let index = $n_words * 8 - 1 - index;
+                self.byte(index)
+            }
 
 			/// Write to the slice in big-endian format.
 			#[inline]

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -7,4 +7,4 @@ description = "Block and transaction types for Ethereum."
 repository = "https://github.com/ethereumproject/etcommon"
 
 [dependencies]
-etcommon-bigint = { path = "../bigint" }
+etcommon-bigint = "0.1.8"

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -7,4 +7,4 @@ description = "Block and transaction types for Ethereum."
 repository = "https://github.com/ethereumproject/etcommon"
 
 [dependencies]
-etcommon-bigint = "0.1.8"
+etcommon-bigint = "0.1.9"

--- a/block/src/bytes.rs
+++ b/block/src/bytes.rs
@@ -1,0 +1,2 @@
+/// Maximum 256-bit byte-array that does not require heap allocation.
+pub struct B256(usize, [u8; 32]);

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -1,9 +1,28 @@
 extern crate etcommon_bigint as bigint;
 
-use bigint::U256;
+mod bytes;
+
+use bytes::B256;
+use bigint::{H256, H160, H2048, U256};
+
+pub type LogsBloom = H2048;
+pub type Address = H160;
+pub type Gas = U256;
 
 pub struct BlockHeader {
-    pub parent_hash: U256,
-    pub ommers_hash: U256,
-
+    pub parent_hash: H256,
+    pub ommers_hash: H256,
+    pub beneficiary: Address,
+    pub state_root: H256,
+    pub transactions_root: H256,
+    pub receipts_root: H256,
+    pub logs_bloom: LogsBloom,
+    pub difficulty: U256,
+    pub number: U256,
+    pub gas_limit: Gas,
+    pub gas_used: Gas,
+    pub timestamp: u64,
+    pub extra_data: B256,
+    pub mix_hash: H256,
+    pub nonce: u64,
 }

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -3,7 +3,7 @@ name = "etcommon-rlp"
 description = "Recursive-length prefix encoding, decoding, and compression"
 repository = "https://github.com/ethereumproject/etcommon"
 license = "MIT/Apache-2.0"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -72,7 +72,7 @@ pub const EMPTY_LIST_RLP: [u8; 1] = [0xC0; 1];
 /// Shortcut function to decode trusted rlp
 ///
 /// ```rust
-/// extern crate sputnikvm_rlp as rlp;
+/// extern crate etcommon_rlp as rlp;
 ///
 /// fn main () {
 /// 	let data = vec![0x83, b'c', b'a', b't'];
@@ -93,7 +93,7 @@ pub fn decode_list<T>(bytes: &[u8]) -> Vec<T> where T: Decodable {
 /// Shortcut function to encode structure into rlp.
 ///
 /// ```rust
-/// extern crate sputnikvm_rlp as rlp;
+/// extern crate etcommon_rlp as rlp;
 ///
 /// fn main () {
 /// 	let animal = "cat";

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -41,7 +41,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// The raw data of the RLP as slice.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -73,7 +73,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Returns number of RLP items.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -91,7 +91,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Returns the number of bytes in the data, or zero if it isn't data.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -112,7 +112,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// slices is faster.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -129,7 +129,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// No value
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -145,7 +145,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Contains a zero-length string or zero-length list.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -161,7 +161,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// List value
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -177,7 +177,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// String value
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -193,7 +193,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Int value
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -210,7 +210,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Get iterator over rlp-slices
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -61,7 +61,7 @@ impl RlpStream {
 	/// Appends value to the end of stream, chainable.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -99,7 +99,7 @@ impl RlpStream {
 	/// Declare appending the list of given size, chainable.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -149,7 +149,7 @@ impl RlpStream {
 	/// Apends null to the end of stream, chainable.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -215,7 +215,7 @@ impl RlpStream {
 	/// Clear the output stream so far.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -237,7 +237,7 @@ impl RlpStream {
 	/// Returns true if stream doesnt expect any more items.
 	///
 	/// ```rust
-	/// extern crate sputnikvm_rlp as rlp;
+	/// extern crate etcommon_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate sputnikvm_rlp as rlp;
+extern crate etcommon_rlp as rlp;
 
 use std::{fmt, cmp};
 use rlp::{Encodable, Decodable, UntrustedRlp, RlpStream, DecoderError};

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -47,3 +47,14 @@ pub fn read_hex(s: &str) -> Result<Vec<u8>, ParseHexError> {
 
     return Ok(res);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::read_hex;
+
+    #[test]
+    fn read_hex_zero() {
+        assert_eq!(read_hex("0x0").unwrap(), vec![0u8]);
+        assert_eq!(read_hex("0").unwrap(), vec![0u8]);
+    }
+}


### PR DESCRIPTION
* `bigint`: rename `byte` to `index`.
* `rlp`: fix wrong crate names.
* `block`: add block-level types.