### PR TITLE
Create transaction signature and recover network_id and address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ etcommon-bigint = "0.2"
 etcommon-block = "0.2"
 etcommon-trie = "0.2"
 etcommon-bloom = "0.2"
+blockchain = "0.1"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,12 @@ etcommon-trie = "0.2"
 etcommon-bloom = "0.2"
 blockchain = "0.1"
 
+[dev-dependencies]
+sputnikvm = "0.5"
+secp256k1-plus = "0.5"
+rand = "0.3.12"
+sha3 = "0.6"
+
 [workspace]
 members = [
   "./rlp",

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-bigint"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Big integer (256-bit and 512-bit) implementation for SputnikVM and other Ethereum Classic clients."

--- a/bigint/src/bytes.rs
+++ b/bigint/src/bytes.rs
@@ -4,6 +4,12 @@ use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
 pub struct B256(usize, [u8; 32]);
 
+impl Default for B256 {
+    fn default() -> B256 {
+        B256(0, [0u8; 32])
+    }
+}
+
 impl Encodable for B256 {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.encoder().encode_value(&self.1[0..self.0])

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."
@@ -15,6 +15,8 @@ secp256k1-plus = "0.5"
 etcommon-bigint = "0.2"
 etcommon-rlp = "0.2"
 etcommon-bloom = "0.2"
+etcommon-trie = "0.2"
+blockchain = "0.1"
 
 [dev-dependencies]
 rand = "0.3.12"

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.3"
+version = "0.2.4"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/ethereumproject/etcommon"
 name = "block"
 
 [dependencies]
+sha3 = "0.6"
+secp256k1-plus = "0.5"
 etcommon-bigint = "0.2"
 etcommon-rlp = "0.2"
 etcommon-bloom = "0.2"

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.2"
+version = "0.2.3"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -17,4 +17,5 @@ etcommon-rlp = "0.2"
 etcommon-bloom = "0.2"
 
 [dev-dependencies]
+rand = "0.3.12"
 etcommon-hexutil = "0.2"

--- a/block/src/address.rs
+++ b/block/src/address.rs
@@ -1,0 +1,22 @@
+use secp256k1::{SECP256K1, Error};
+use secp256k1::key::{PublicKey, SecretKey};
+use bigint::{H256, Address};
+use sha3::{Digest, Keccak256};
+
+pub trait FromKey: Sized {
+    fn from_public_key(key: &PublicKey) -> Self;
+    fn from_secret_key(key: &SecretKey) -> Result<Self, Error>;
+}
+
+impl FromKey for Address {
+    fn from_public_key(key: &PublicKey) -> Self {
+        let hash = H256::from(
+            Keccak256::digest(&key.serialize_vec(&SECP256K1, false)[1..]).as_slice());
+        Address::from(hash)
+    }
+
+    fn from_secret_key(key: &SecretKey) -> Result<Self, Error> {
+        let public_key = PublicKey::from_secret_key(&SECP256K1, key)?;
+        Ok(Self::from_public_key(&public_key))
+    }
+}

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -3,6 +3,8 @@ extern crate rlp;
 extern crate bloom;
 extern crate secp256k1;
 extern crate sha3;
+extern crate blockchain;
+extern crate trie;
 #[cfg(test)] extern crate hexutil;
 #[cfg(test)] extern crate rand;
 

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -16,7 +16,7 @@ mod receipt;
 mod log;
 mod address;
 
-pub use transaction::{TransactionSignature, TransactionAction, Transaction};
+pub use transaction::{UnsignedTransaction, TransactionSignature, TransactionAction, Transaction};
 pub use header::Header;
 pub use block::Block;
 pub use account::Account;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -4,6 +4,7 @@ extern crate bloom;
 extern crate secp256k1;
 extern crate sha3;
 #[cfg(test)] extern crate hexutil;
+#[cfg(test)] extern crate rand;
 
 mod header;
 mod transaction;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate bigint;
 extern crate rlp;
 extern crate bloom;
+extern crate secp256k1;
+extern crate sha3;
 #[cfg(test)] extern crate hexutil;
 
 mod header;
@@ -9,6 +11,7 @@ mod block;
 mod account;
 mod receipt;
 mod log;
+mod address;
 
 pub use transaction::{TransactionSignature, TransactionAction, Transaction};
 pub use header::Header;
@@ -16,3 +19,4 @@ pub use block::Block;
 pub use account::Account;
 pub use receipt::Receipt;
 pub use log::Log;
+pub use address::FromKey;

--- a/block/src/transaction.rs
+++ b/block/src/transaction.rs
@@ -1,11 +1,36 @@
-use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
+use secp256k1::{Message, Error, RecoverableSignature, RecoveryId, SECP256K1};
+use secp256k1::key::{PublicKey, SecretKey};
+use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 use bigint::{Address, Gas, H256, U256, B256};
+use sha3::{Digest, Keccak256};
+use address::FromKey;
+
+const ECDSA_SIGNATURE_BYTES: usize = 65;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionSignature {
-    pub v: u64,
-    pub r: U256,
-    pub s: U256,
+    pub v: u8,
+    pub r: H256,
+    pub s: H256,
+}
+
+impl TransactionSignature {
+    pub fn standard_v(&self) -> u8 {
+        let v = self.v;
+        if v == 27 || v == 28 || v > 36 {
+            ((v - 1) % 2) as u8
+        } else {
+            4
+        }
+    }
+
+    pub fn into_recoverable_signature(self) -> Result<RecoverableSignature, Error> {
+        let mut sig = [0u8; 64];
+        sig[0..32].copy_from_slice(&self.r);
+        sig[32..64].copy_from_slice(&self.s);
+
+        RecoverableSignature::from_compact(&SECP256K1, &sig, RecoveryId::from_i32(self.standard_v() as i32)?)
+    }
 }
 
 // Use transaction action so we can keep most of the common fields
@@ -39,6 +64,76 @@ impl Decodable for TransactionAction {
     }
 }
 
+pub struct UnsignedTransaction {
+    pub nonce: U256,
+    pub gas_price: Gas,
+    pub gas_limit: Gas,
+    pub action: TransactionAction,
+    pub value: U256,
+    pub input: Vec<u8>,
+    pub network_id: Option<u8>,
+}
+
+impl UnsignedTransaction {
+    pub fn sign(self, key: &SecretKey) -> Transaction {
+        let hash = H256::from(Keccak256::digest(&rlp::encode(&self).to_vec()).as_slice());
+        // hash is always MESSAGE_SIZE bytes.
+        let msg = Message::from_slice(&hash).unwrap();
+
+        // SecretKey and Message are always valid.
+        let s = SECP256K1.sign_recoverable(&msg, key).unwrap();
+        let (rid, sig) = s.serialize_compact(&SECP256K1);
+
+        let sig = TransactionSignature {
+            v: (rid.to_i32() + if let Some(n) = self.network_id { (35 + n * 2) as i32 } else { 27 }) as u8,
+            r: H256::from(&sig[0..32]),
+            s: H256::from(&sig[32..64]),
+        };
+
+        Transaction {
+            nonce: self.nonce,
+            gas_price: self.gas_price,
+            gas_limit: self.gas_limit,
+            action: self.action,
+            value: self.value,
+            input: self.input,
+            signature: sig,
+        }
+    }
+}
+
+impl Encodable for UnsignedTransaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(if self.network_id.is_some() { 9 } else { 6 });
+        s.append(&self.nonce);
+        s.append(&self.gas_price);
+        s.append(&self.gas_limit);
+        s.append(&self.action);
+        s.append(&self.value);
+        s.append(&self.input);
+
+        if let Some(network_id) = self.network_id {
+            s.append(&network_id);
+            s.append(&0u8);
+            s.append(&0u8);
+        }
+    }
+}
+
+impl From<Transaction> for UnsignedTransaction {
+    fn from(val: Transaction) -> UnsignedTransaction {
+        UnsignedTransaction {
+            network_id: val.network_id(),
+            nonce: val.nonce,
+            gas_price: val.gas_price,
+            gas_limit: val.gas_limit,
+            action: val.action,
+            value: val.value,
+            input: val.input,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Transaction {
     pub nonce: U256,
@@ -48,6 +143,24 @@ pub struct Transaction {
     pub value: U256,
     pub signature: TransactionSignature,
     pub input: Vec<u8>, // The input data, either data or init, depending on TransactionAction.
+}
+
+impl Transaction {
+    pub fn address(&self) -> Result<Address, Error> {
+        let hash = H256::from(Keccak256::digest(&rlp::encode(&UnsignedTransaction::from(self.clone())).to_vec()).as_slice());
+        let sig = self.signature.clone().into_recoverable_signature()?;
+        let public_key = SECP256K1.recover(&Message::from_slice(&hash).unwrap(), &sig)?;
+
+        Ok(Address::from_public_key(&public_key))
+    }
+
+    pub fn network_id(&self) -> Option<u8> {
+        if self.signature.v > 36 {
+            Some((self.signature.v - 35) / 2)
+        } else {
+            None
+        }
+    }
 }
 
 impl Encodable for Transaction {
@@ -80,5 +193,38 @@ impl Decodable for Transaction {
                 s: rlp.val_at(8)?,
             },
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use secp256k1::{Message, Error, RecoverableSignature, RecoveryId, SECP256K1};
+    use secp256k1::key::{PublicKey, SecretKey};
+    use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
+    use bigint::{Address, Gas, H256, U256, B256};
+    use sha3::{Digest, Keccak256};
+    use address::FromKey;
+    use rand::os::OsRng;
+    use super::{Transaction, UnsignedTransaction, TransactionAction};
+
+    #[test]
+    pub fn should_recover_address() {
+        let mut rng = OsRng::new().unwrap();
+        let secret_key = SecretKey::new(&SECP256K1, &mut rng);
+        let address = Address::from_secret_key(&secret_key);
+
+        let unsigned = UnsignedTransaction {
+            nonce: U256::zero(),
+            gas_price: Gas::zero(),
+            gas_limit: Gas::zero(),
+            action: TransactionAction::Create,
+            value: U256::zero(),
+            input: Vec::new(),
+            network_id: Some(61),
+        };
+        let signed = unsigned.sign(&secret_key);
+
+        assert_eq!(signed.network_id(), Some(61));
+        assert_eq!(signed.address(), address);
     }
 }

--- a/block/src/transaction.rs
+++ b/block/src/transaction.rs
@@ -146,7 +146,7 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    pub fn address(&self) -> Result<Address, Error> {
+    pub fn caller(&self) -> Result<Address, Error> {
         let hash = H256::from(Keccak256::digest(&rlp::encode(&UnsignedTransaction::from(self.clone())).to_vec()).as_slice());
         let sig = self.signature.clone().into_recoverable_signature()?;
         let public_key = SECP256K1.recover(&Message::from_slice(&hash).unwrap(), &sig)?;

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-bloom"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Log bloom implementation for Ethereum."

--- a/bloom/src/lib.rs
+++ b/bloom/src/lib.rs
@@ -6,6 +6,7 @@ extern crate rlp;
 extern crate hexutil;
 extern crate sha3;
 
+use std::ops::BitOr;
 use bigint::H2048;
 use sha3::{Digest, Keccak256};
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
@@ -41,6 +42,14 @@ impl Decodable for LogsBloom {
 impl Default for LogsBloom {
     fn default() -> LogsBloom {
         LogsBloom(H2048::zero())
+    }
+}
+
+impl BitOr for LogsBloom {
+    type Output = LogsBloom;
+
+    fn bitor(self, other: LogsBloom) -> LogsBloom {
+        LogsBloom(self.0 | other.0)
     }
 }
 

--- a/examples/sputnikvm.rs
+++ b/examples/sputnikvm.rs
@@ -1,0 +1,292 @@
+extern crate blockchain;
+extern crate etcommon;
+extern crate sputnikvm;
+extern crate secp256k1;
+extern crate rand;
+extern crate sha3;
+
+use etcommon::EthereumDefinition;
+use etcommon::block::{Receipt, Block, UnsignedTransaction, Transaction, TransactionAction, Log, FromKey, Header, Account};
+use etcommon::trie::{empty_trie_hash, MemoryTrie};
+use etcommon::bigint::{H256, M256, U256, H64, B256, Gas, Address};
+use etcommon::bloom::LogsBloom;
+use etcommon::rlp;
+use sputnikvm::vm::{self, VM};
+use secp256k1::SECP256K1;
+use secp256k1::key::{PublicKey, SecretKey};
+use std::time::Duration;
+use std::thread;
+use std::collections::HashMap;
+use std::str::FromStr;
+use rand::os::OsRng;
+use sha3::{Keccak256, Digest};
+
+pub struct EthereumTransitionRule;
+
+impl blockchain::TransitionRule for EthereumTransitionRule {
+    type Block = Block;
+    type Transaction = Transaction;
+    type Extra = Receipt;
+    type WorldState = MemoryTrie;
+
+    fn transit(
+        current_block: &Block,
+        transaction: &Transaction,
+        state: &MemoryTrie
+    ) -> (MemoryTrie, Receipt) {
+        let mut state = state.clone();
+        let transaction_cloned = transaction.clone();
+
+        let transaction = match transaction.action.clone() {
+            TransactionAction::Create => {
+                vm::Transaction::ContractCreation {
+                    caller: transaction_cloned.caller().unwrap(),
+                    gas_price: transaction_cloned.gas_price,
+                    gas_limit: transaction_cloned.gas_limit,
+                    value: transaction_cloned.value,
+                    init: transaction_cloned.input,
+                }
+            },
+            TransactionAction::Call(addr) => {
+                vm::Transaction::MessageCall {
+                    address: addr,
+                    caller: transaction_cloned.caller().unwrap(),
+                    gas_price: transaction_cloned.gas_price,
+                    gas_limit: transaction_cloned.gas_limit,
+                    value: transaction_cloned.value,
+                    data: transaction_cloned.input,
+                }
+            },
+        };
+
+        let header = vm::BlockHeader {
+            coinbase: current_block.header.beneficiary,
+            timestamp: M256::from(current_block.header.timestamp),
+            number: M256::from(current_block.header.number),
+            difficulty: M256::from(current_block.header.difficulty),
+            gas_limit: current_block.header.gas_limit,
+        };
+
+        let mut vm = vm::SeqTransactionVM::new(transaction, header, &vm::EIP160_PATCH);
+
+        loop {
+            match vm.fire() {
+                Ok(()) => break,
+                Err(vm::errors::RequireError::Account(addr)) => {
+                    println!("Requiring account {:?}", addr);
+
+                    let account_rlp = state.get(addr.as_ref());
+                    if account_rlp.is_none() {
+                        vm.commit_account(vm::AccountCommitment::Nonexist(addr)).unwrap();;
+                    } else {
+                        let account_rlp = account_rlp.unwrap();
+                        let account: Account = rlp::decode(&account_rlp);
+                        let code = state.get(account.code_hash.as_ref());
+
+                        vm.commit_account(vm::AccountCommitment::Full {
+                            nonce: account.nonce.into(),
+                            address: addr,
+                            balance: account.balance,
+                            code: code.unwrap_or(Vec::new()),
+                        }).unwrap();
+                    }
+                },
+                Err(vm::errors::RequireError::AccountCode(addr)) => {
+                    println!("Requiring account code {:?}", addr);
+
+                    let account_rlp = state.get(addr.as_ref());
+                    if account_rlp.is_none() {
+                        vm.commit_account(vm::AccountCommitment::Nonexist(addr)).unwrap();;
+                    } else {
+                        let account_rlp = account_rlp.unwrap();
+                        let account: Account = rlp::decode(&account_rlp);
+                        let code = state.get(account.code_hash.as_ref());
+
+                        vm.commit_account(vm::AccountCommitment::Code {
+                            address: addr,
+                            code: code.unwrap_or(Vec::new()),
+                        }).unwrap();
+                    }
+                },
+                Err(vm::errors::RequireError::AccountStorage(addr, index)) => {
+                    println!("Requiring account storage {:?}", addr);
+
+                    let account_rlp = state.get(addr.as_ref());
+                    if account_rlp.is_none() {
+                        vm.commit_account(vm::AccountCommitment::Nonexist(addr)).unwrap();;
+                    } else {
+                        let account_rlp = account_rlp.unwrap();
+                        let account: Account = rlp::decode(&account_rlp);
+                        let mut storage = state.clone();
+                        storage.set_root(account.storage_root);
+
+                        let mut key_raw = Vec::new();
+                        let key: U256 = index.into();
+                        key.to_big_endian(&mut key_raw);
+                        vm.commit_account(vm::AccountCommitment::Storage {
+                            address: addr,
+                            index: index,
+                            value: M256::from(storage.get(key_raw.as_ref()).unwrap_or(Vec::new()).as_ref()),
+                        }).unwrap();
+                    }
+                },
+                _ => unimplemented!(),
+            }
+        }
+
+        let mut state = state.clone();
+        for account in vm.accounts() {
+            match account.clone() {
+                vm::Account::Full {
+                    nonce, address, balance, changing_storage, code
+                } => {
+                    let storage: HashMap<M256, M256> = changing_storage.into();
+                    let state_root = state.root();
+                    let account_rlp = state.get(address.as_ref()).unwrap();
+                    let mut account: Account = rlp::decode(&account_rlp);
+
+                    state.set_root(account.storage_root);
+                    for (key, value) in storage {
+                        let mut key_raw = Vec::new();
+                        let mut value_raw = Vec::new();
+                        let key: U256 = key.into();
+                        let value: U256 = value.into();
+                        key.to_big_endian(&mut key_raw);
+                        value.to_big_endian(&mut value_raw);
+                        state.insert(key_raw, value_raw);
+                    }
+                    account.storage_root = state.root();
+                    account.nonce = nonce.into();
+                    account.balance = balance;
+                    let account_rlp = rlp::encode(&account).to_vec();
+                    state.set_root(state_root);
+                    state.insert(address.as_ref().into(), account_rlp);
+                },
+                vm::Account::IncreaseBalance(address, value) => {
+                    let state_root = state.root();
+                    let account_rlp = state.get(address.as_ref()).unwrap();
+                    let mut account: Account = rlp::decode(&account_rlp);
+                    account.balance = account.balance + value;
+                    let account_rlp = rlp::encode(&account).to_vec();
+                    state.set_root(state_root);
+                    state.insert(address.as_ref().into(), account_rlp);
+                },
+                vm::Account::DecreaseBalance(address, value) => {
+                    let state_root = state.root();
+                    let account_rlp = state.get(address.as_ref()).unwrap();
+                    let mut account: Account = rlp::decode(&account_rlp);
+                    account.balance = account.balance - value;
+                    let account_rlp = rlp::encode(&account).to_vec();
+                    state.set_root(state_root);
+                    state.insert(address.as_ref().into(), account_rlp);
+                },
+                vm::Account::Create {
+                    nonce, address, balance, storage, code, exists
+                } => {
+                    if !exists {
+                        state.remove(address.as_ref());
+                    } else {
+                        let storage: HashMap<M256, M256> = storage.into();
+                        let state_root = state.root();
+                        let code_hash = H256::from(Keccak256::digest(code.as_ref()).as_slice());
+                        let mut account: Account = Account {
+                            balance: balance,
+                            nonce: nonce.into(),
+                            code_hash: code_hash,
+                            storage_root: empty_trie_hash(),
+                        };
+
+                        state.insert(code_hash.as_ref().into(), code);
+
+                        state.set_root(account.storage_root);
+                        for (key, value) in storage {
+                            let mut key_raw = Vec::new();
+                            let mut value_raw = Vec::new();
+                            let key: U256 = key.into();
+                            let value: U256 = value.into();
+                            key.to_big_endian(&mut key_raw);
+                            value.to_big_endian(&mut value_raw);
+                            state.insert(key_raw, value_raw);
+                        }
+                        account.storage_root = state.root();
+                        account.nonce = nonce.into();
+                        account.balance = balance;
+                        let account_rlp = rlp::encode(&account).to_vec();
+                        state.set_root(state_root);
+                        state.insert(address.as_ref().into(), account_rlp);
+                    }
+                }
+            }
+        }
+
+        let logs: Vec<Log> = vm.logs().into();
+        let used_gas = vm.real_used_gas();
+        let mut logs_bloom = LogsBloom::new();
+        for log in logs.clone() {
+            logs_bloom.set(&log.address);
+            for topic in log.topics {
+                logs_bloom.set(&topic)
+            }
+        }
+
+        let receipt = Receipt {
+            used_gas, logs, logs_bloom, state_root: state.root(),
+        };
+
+        (state, receipt)
+    }
+}
+
+fn main() {
+    let mut rng = OsRng::new().unwrap();
+    let secret_key = SecretKey::new(&SECP256K1, &mut rng);
+    let address = Address::from_secret_key(&secret_key).unwrap();
+    println!("address: {:?}", address);
+    let mut state = MemoryTrie::empty(HashMap::new());
+
+    state.insert(address.as_ref().into(), rlp::encode(&Account {
+        nonce: U256::zero(),
+        balance: U256::from_str("0x10000000000000000000000000000").unwrap(),
+        storage_root: empty_trie_hash(),
+        code_hash: H256::from(Keccak256::digest(&[]).as_slice()),
+    }).to_vec());
+
+    let mut blockchain: blockchain::Blockchain<EthereumDefinition<blockchain::FakeConsensus<Block, Receipt>, EthereumTransitionRule>> = blockchain::Blockchain::new(Block {
+        header: Header {
+            parent_hash: H256::default(),
+            ommers_hash: empty_trie_hash(),
+            beneficiary: Address::default(),
+            state_root: empty_trie_hash(),
+            transactions_root: empty_trie_hash(),
+            receipts_root: empty_trie_hash(),
+            logs_bloom: LogsBloom::new(),
+            difficulty: U256::zero(),
+            number: U256::zero(),
+            gas_limit: Gas::zero(),
+            gas_used: Gas::zero(),
+            timestamp: 0,
+            extra_data: B256::default(),
+            mix_hash: H256::default(),
+            nonce: H64::default(),
+        },
+        transactions: Vec::new(),
+        ommers: Vec::new(),
+    }, state);
+
+    loop {
+        let unsigned = UnsignedTransaction {
+            nonce: U256::zero(),
+            gas_price: Gas::zero(),
+            gas_limit: Gas::from_str("0x100000000").unwrap(),
+            action: TransactionAction::Create,
+            value: U256::zero(),
+            input: Vec::new(),
+            network_id: Some(61),
+        };
+        let signed = unsigned.sign(&secret_key);
+        blockchain.mine(&[signed]);
+        println!("Mined one block, {:?}", blockchain.current_block());
+
+        thread::sleep(Duration::from_millis(1000));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct EthereumDefinition<C, T> {
 }
 
 impl<C: blockchain::Consensus<Block=Block, Extra=Receipt>,
-     T: blockchain::TransitionRule<Transaction=Transaction, Extra=Receipt, WorldState=MemoryTrie>>
+     T: blockchain::TransitionRule<Block=Block, Transaction=Transaction, Extra=Receipt, WorldState=MemoryTrie>>
     blockchain::Definition
     for EthereumDefinition<C, T>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,29 @@ pub extern crate hexutil;
 pub extern crate block;
 pub extern crate bloom;
 pub extern crate trie;
+
+extern crate blockchain;
+
+use bigint::H256;
+use block::{Block, Receipt, Transaction};
+use trie::MemoryTrie;
+use std::marker::PhantomData;
+
+pub struct EthereumDefinition<C, T> {
+    consensus: PhantomData<C>,
+    transition_rule: PhantomData<T>
+}
+
+impl<C: blockchain::Consensus<Block=Block, Extra=Receipt>,
+     T: blockchain::TransitionRule<Transaction=Transaction, Extra=Receipt, WorldState=MemoryTrie>>
+    blockchain::Definition
+    for EthereumDefinition<C, T>
+{
+    type Transaction = Transaction;
+    type Extra = Receipt;
+    type Hash = H256;
+    type WorldState = MemoryTrie;
+    type Block = Block;
+    type TransitionRule = T;
+    type Consensus = C;
+}

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-trie"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Lightweight Ethereum world state storage."

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-trie"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Lightweight Ethereum world state storage."
@@ -12,6 +12,7 @@ name = "trie"
 [dependencies]
 etcommon-bigint = "0.2"
 etcommon-rlp = "0.2"
+blockchain = "0.1"
 sha3 = "0.6"
 
 [dev-dependencies]

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-trie"
-version = "0.2.3"
+version = "0.2.4"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Lightweight Ethereum world state storage."

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-trie"
-version = "0.2.2"
+version = "0.2.3"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Lightweight Ethereum world state storage."

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate bigint;
 extern crate rlp;
 extern crate sha3;
+extern crate blockchain;
 #[cfg(test)] extern crate hexutil;
 
 pub mod merkle;
@@ -16,6 +17,7 @@ use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
 use std::ops::{Deref, DerefMut};
 use std::borrow::Borrow;
 use std::clone::Clone;
+use blockchain::Hashable;
 
 use self::cache::Cache;
 use self::database::{Database, Change, ChangeSet};
@@ -40,6 +42,12 @@ fn empty_trie_hash() -> H256 {
 pub struct Trie<D: Database> {
     database: D,
     root: H256,
+}
+
+impl<D: Database> Hashable<H256> for Tire<D> {
+    fn hash(&self) -> H256 {
+        self.root()
+    }
 }
 
 impl<D: Database> Trie<D> {

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -39,6 +39,8 @@ fn empty_trie_hash() -> H256 {
     H256::from("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 }
 
+pub type MemoryTrie = Trie<HashMap<H256, Vec<u8>>>;
+
 pub struct Trie<D: Database> {
     database: D,
     root: H256,

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -35,7 +35,7 @@ macro_rules! empty_nodes {
     )
 }
 
-fn empty_trie_hash() -> H256 {
+pub fn empty_trie_hash() -> H256 {
     H256::from("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 }
 
@@ -56,6 +56,10 @@ impl<D: Database> Hashable<H256> for Trie<D> {
 impl<D: Database> Trie<D> {
     pub fn root(&self) -> H256 {
         self.root
+    }
+
+    pub fn set_root(&mut self, root: H256) {
+        self.root = root;
     }
 
     pub fn is_empty(&self) -> bool {

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -41,6 +41,7 @@ fn empty_trie_hash() -> H256 {
 
 pub type MemoryTrie = Trie<HashMap<H256, Vec<u8>>>;
 
+#[derive(Clone, Debug)]
 pub struct Trie<D: Database> {
     database: D,
     root: H256,

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -44,7 +44,7 @@ pub struct Trie<D: Database> {
     root: H256,
 }
 
-impl<D: Database> Hashable<H256> for Tire<D> {
+impl<D: Database> Hashable<H256> for Trie<D> {
     fn hash(&self) -> H256 {
         self.root()
     }


### PR DESCRIPTION
Stole some code from emerald-rs. But there're some major difference if we want to merge those two together:

* It uses `secp256k1-plus` instead of `secp256k1`.
* It does not use any notion of `PrivateKey` struct, but relies on `secp256k1-plus`'s `SecretKey`.
* It uses `etcommon-bigint`'s `H256` and `H160/Address` instead of `[u8; 32]`.