### PR TITLE
hexutil: add a to-hex function

### DIFF
--- a/hexutil/Cargo.toml
+++ b/hexutil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-hexutil"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Hex helper functions."

--- a/hexutil/src/lib.rs
+++ b/hexutil/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 
 #[derive(Debug)]
 /// Errors exhibited from `read_hex`.
@@ -55,6 +56,16 @@ pub fn read_hex(s: &str) -> Result<Vec<u8>, ParseHexError> {
     }
 
     return Ok(res);
+}
+
+/// Given a bytearray, get a Ethereum-compatible string hex.
+pub fn to_hex(a: &[u8]) -> String {
+    let mut s = String::new();
+    write!(s, "0x").unwrap();
+    for v in a {
+        write!(s, "{:02x}", *v).unwrap();
+    }
+    s
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows converting from a slice to a Ethereum-compatible hex string.