### PR TITLE
trie: make get/insert/remove generic typed

### DIFF
--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -15,7 +15,6 @@ secp256k1-plus = "0.5"
 etcommon-bigint = "0.2"
 etcommon-rlp = "0.2"
 etcommon-bloom = "0.2"
-etcommon-trie = "0.2"
 blockchain = "0.1"
 
 [dev-dependencies]

--- a/block/src/block.rs
+++ b/block/src/block.rs
@@ -1,6 +1,5 @@
 use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 use bigint::{Address, Gas, H256, U256, B256, H64, H2048};
-use trie::MemoryTrie;
 use bloom::LogsBloom;
 use sha3::{Keccak256, Digest};
 use std::collections::HashMap;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -4,7 +4,6 @@ extern crate bloom;
 extern crate secp256k1;
 extern crate sha3;
 extern crate blockchain;
-extern crate trie;
 #[cfg(test)] extern crate hexutil;
 #[cfg(test)] extern crate rand;
 

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-trie"
-version = "0.2.8"
+version = "0.3.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Lightweight Ethereum world state storage."


### PR DESCRIPTION
So there's no need to convert to `Vec<u8>` every time interacting with the trie.