### PR TITLE
Usability fix for block and bigint

### DIFF
--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-bigint"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Big integer (256-bit and 512-bit) implementation for SputnikVM and other Ethereum Classic clients."

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -14,8 +14,8 @@ heapsize = "0.4"
 byteorder = "1.0"
 rand = "0.3.12"
 libc = "0.2"
-etcommon-rlp = "0.2"
-etcommon-hexutil = "0.2"
+etcommon-rlp = { version = "0.2", path = "../rlp" }
+etcommon-hexutil = { version = "0.2", path = "../hexutil" }
 
 [features]
 x64asm_arithmetic=[]

--- a/bigint/src/hash/mod.rs
+++ b/bigint/src/hash/mod.rs
@@ -21,6 +21,7 @@ use rand::os::OsRng;
 use super::U256;
 use libc::{c_void, memcmp};
 use hexutil::{read_hex, ParseHexError, clean_0x};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 macro_rules! impl_hash {
 	($from: ident, $size: expr) => {
@@ -439,6 +440,12 @@ impl<'a> From<&'a H160> for H256 {
     }
 }
 
+impl Into<u64> for H64 {
+    fn into(self) -> u64 {
+        self.0.as_ref().read_u64::<BigEndian>().unwrap()
+    }
+}
+
 impl_hash!(H32, 4);
 impl_hash!(H64, 8);
 impl_hash!(H128, 16);
@@ -563,5 +570,13 @@ mod tests {
         assert_eq!(r_ref, u);
         let r: U256 = From::from(h);
         assert_eq!(r, u);
+    }
+
+    #[test]
+    fn from_and_to_u64() {
+        let v: u64 = 10298314;
+        let h: H64 = H64::from(v);
+        let v2: u64 = h.into();
+        assert_eq!(v, v2);
     }
 }

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.5"
+version = "0.2.6"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -12,9 +12,9 @@ name = "block"
 [dependencies]
 sha3 = "0.6"
 secp256k1-plus = "0.5"
-etcommon-bigint = "0.2"
-etcommon-rlp = "0.2"
-etcommon-bloom = "0.2"
+etcommon-bigint = { version = "0.2", path = "../bigint" }
+etcommon-rlp = { version = "0.2", path = "../rlp" }
+etcommon-bloom = { version = "0.2", path = "../bloom" }
 blockchain = "0.1"
 
 [dev-dependencies]

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.6"
+version = "0.2.7"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/src/header.rs
+++ b/block/src/header.rs
@@ -162,6 +162,16 @@ pub struct PartialHeader {
     pub extra_data: B256,
 }
 
+impl HeaderHash<H256> for PartialHeader {
+    fn parent_hash(&self) -> H256 {
+        self.parent_hash
+    }
+
+    fn header_hash(&self) -> H256 {
+        H256::from(Keccak256::digest(&rlp::encode(self).to_vec()).as_slice())
+    }
+}
+
 impl PartialHeader {
     pub fn from_full(header: Header) -> Self {
         Self {

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -16,7 +16,7 @@ mod log;
 mod address;
 
 pub use transaction::{UnsignedTransaction, TransactionSignature, TransactionAction, Transaction};
-pub use header::Header;
+pub use header::{TotalHeader, PartialHeader, Header};
 pub use block::Block;
 pub use account::Account;
 pub use receipt::Receipt;

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/ethereumproject/etcommon-rs"
 name = "bloom"
 
 [dependencies]
-etcommon-rlp = "0.2"
-etcommon-bigint = "0.2"
+etcommon-rlp = { version = "0.2", path = "../rlp" }
+etcommon-bigint = { version = "0.2", path = "../bigint" }
 sha3 = "0.6"
 
 [dev-dependencies]

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/ethereumproject/etcommon-rs"
 name = "trie"
 
 [dependencies]
-etcommon-bigint = "0.2"
-etcommon-rlp = "0.2"
+etcommon-bigint = { version = "0.2", path = "../bigint" }
+etcommon-rlp = { version = "0.2", path = "../rlp" }
 sha3 = "0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
- Fix `block` where PartialHeader and TotalHeader is not exported.
- Add `Into<u64>` for H64. Useful for nonce conversion in `ethash`.