### PR TITLE
Usability fixes for block

### DIFF
--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.2.7"
+version = "0.2.8"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."


### PR DESCRIPTION
Allow getting the actual address (`to`) of the transaction when it is a contract creation.