### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/trie/src/merkle/nibble.rs
+++ b/trie/src/merkle/nibble.rs
@@ -118,7 +118,8 @@ pub fn encode(vec: NibbleSlice, typ: NibbleType, s: &mut RlpStream) {
                 ret.push(v << 4);
             } else {
                 let end = ret.len() - 1;
-                ret[end] |= vec[i].into();
+                let nibble: u8 = vec[i].into();
+                ret[end] |= nibble;
             }
         }
     } else {
@@ -127,7 +128,8 @@ pub fn encode(vec: NibbleSlice, typ: NibbleType, s: &mut RlpStream) {
         for i in 0..vec.len() {
             if i & 1 == 0 {
                 let end = ret.len() - 1;
-                ret[end] |= vec[i].into();
+                let nibble: u8 = vec[i].into();
+                ret[end] |= nibble;
             } else {
                 let v: u8 = vec[i].into();
                 ret.push(v << 4);


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.