### PR TITLE
Trie traverse implementation

### DIFF
--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-trie"
-version = "0.3.6"
+version = "0.3.7"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Lightweight Ethereum world state storage."

--- a/trie/src/database/mod.rs
+++ b/trie/src/database/mod.rs
@@ -25,10 +25,10 @@ pub trait Database<'a> {
     fn create_secure_empty(&'a self) -> SecureTrie<Self::Guard> {
         SecureTrie::new(self.create_empty())
     }
-    fn create_fixed_trie<K: rlp::Encodable, V: rlp::Encodable + rlp::Decodable>(&'a self, root: H256) -> FixedTrie<Self::Guard, K, V> {
+    fn create_fixed_trie<K: rlp::Encodable + rlp::Decodable, V: rlp::Encodable + rlp::Decodable>(&'a self, root: H256) -> FixedTrie<Self::Guard, K, V> {
         FixedTrie::new(self.create_trie(root))
     }
-    fn create_fixed_empty<K: rlp::Encodable, V: rlp::Encodable + rlp::Decodable>(&'a self) -> FixedTrie<Self::Guard, K, V> {
+    fn create_fixed_empty<K: rlp::Encodable + rlp::Decodable, V: rlp::Encodable + rlp::Decodable>(&'a self) -> FixedTrie<Self::Guard, K, V> {
         FixedTrie::new(self.create_empty())
     }
     fn create_fixed_secure_trie<K: AsRef<[u8]>, V: rlp::Encodable + rlp::Decodable>(&'a self, root: H256) -> FixedSecureTrie<Self::Guard, K, V> {

--- a/trie/src/iter.rs
+++ b/trie/src/iter.rs
@@ -1,0 +1,126 @@
+use database::DatabaseGuard;
+use merkle::{MerkleNode, MerkleValue};
+use merkle::nibble::{into_key, NibbleVec};
+use rlp::{self, Rlp};
+
+use std::ops::Deref;
+
+pub struct MerkleIterator<'a, D: DatabaseGuard + 'a> {
+    database: &'a D,
+    prefix: NibbleVec,
+    value: Vec<u8>,
+    index: usize,
+    child: Option<Box<MerkleIterator<'a, D>>>,
+}
+
+impl<'a, D: DatabaseGuard + 'a> MerkleIterator<'a, D> {
+    pub fn new(database: &'a D, value: Vec<u8>) -> Self {
+        Self {
+            database, value,
+            index: 0, child: None, prefix: NibbleVec::new(),
+        }
+    }
+}
+
+fn prepare_value_as_child<'a, D: DatabaseGuard + 'a>(
+    database: &'a D, prefix: NibbleVec, subnibble: NibbleVec, value: MerkleValue
+) -> Option<Box<MerkleIterator<'a, D>>> {
+    let mut nibble = prefix.clone();
+    nibble.extend(subnibble);
+
+    match value {
+        MerkleValue::Empty => None,
+        MerkleValue::Full(sub_node) => {
+            let value = rlp::encode(sub_node.deref()).to_vec();
+            Some(Box::new(
+                MerkleIterator {
+                    database: database,
+                    prefix: nibble,
+                    value, index: 0, child: None
+                }
+            ))
+        },
+        MerkleValue::Hash(h) => {
+            let value = database.get(h).unwrap();
+            Some(Box::new(
+                MerkleIterator {
+                    database: database,
+                    prefix: nibble,
+                    value, index: 0, child: None
+                }
+            ))
+        }
+    }
+}
+
+impl<'a, D: DatabaseGuard + 'a> Iterator for MerkleIterator<'a, D> {
+    type Item = (Vec<u8>, Vec<u8>);
+
+    fn next(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        let node = MerkleNode::decode(&Rlp::new(&self.value));
+
+        match node {
+            MerkleNode::Leaf(node_nibble, node_value) => {
+                debug_assert!(self.child.is_none());
+
+                if self.index == 0 {
+                    self.index += 1;
+
+                    let mut nibble = self.prefix.clone();
+                    nibble.extend(node_nibble);
+
+                    Some((into_key(&nibble), node_value.into()))
+                } else {
+                    None
+                }
+            },
+            MerkleNode::Extension(node_nibble, node_value) => {
+                if self.index == 0 {
+                    debug_assert!(self.child.is_none());
+
+                    self.child = prepare_value_as_child(
+                        self.database, self.prefix.clone(), node_nibble, node_value);
+
+                    if self.child.is_some() {
+                        self.index += 1;
+                        self.child.as_mut().unwrap().next()
+                    } else {
+                        None
+                    }
+                } else {
+                    debug_assert!(self.child.is_some());
+
+                    self.child.as_mut().unwrap().next()
+                }
+            },
+            MerkleNode::Branch(nodes, additional) => {
+                debug_assert!(self.index <= 17);
+                while self.index <= 16 {
+                    if self.index < 16 {
+                        if self.child.is_some() {
+                            match self.child.as_mut().unwrap().next() {
+                                Some(val) => return Some(val),
+                                None => {
+                                    self.child = None;
+                                },
+                            }
+                        } else {
+                            let value = nodes[self.index].clone();
+                            let subnibble = vec![self.index.into()];
+                            self.index += 1;
+                            self.child = prepare_value_as_child(
+                                self.database, self.prefix.clone(), subnibble, value);
+                        }
+                    } else {
+                        self.index += 1;
+                        match additional {
+                            Some(val) => return Some((into_key(&self.prefix), val.into())),
+                            None => (),
+                        }
+                    }
+                }
+                None
+            },
+        }
+    }
+}

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -778,6 +778,17 @@ mod tests {
                         "puppy".as_bytes().into());
         trie.insert_raw("dogglesworth".as_bytes().into(),
                         "cat".as_bytes().into());
+
+        let mut all_key_values: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+        all_key_values.insert("doe".as_bytes().into(), "reindeer".as_bytes().into());
+        all_key_values.insert("dog".as_bytes().into(), "puppy".as_bytes().into());
+        all_key_values.insert("dogglesworth".as_bytes().into(), "cat".as_bytes().into());
+
+        for (key, value) in trie.iter() {
+            assert_eq!(all_key_values.get(&key), Some(&value));
+            all_key_values.remove(&key);
+        }
+
         assert_eq!(trie.root(), H256::from_str("0x8aad789dff2f538bca5d8ea56e8abe10f4c7ba3a5dea95fea4cd6e7c3a1168d3").unwrap());
     }
 

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -18,7 +18,7 @@ use self::cache::Cache;
 use self::database::{Change, ChangeSet};
 
 pub use self::database::{Database, DatabaseOwned, DatabaseGuard, MemoryDatabase, MemoryDatabaseGuard};
-pub use self::iter::MerkleIterator;
+pub use self::iter::{FixedMerkleIterator, MerkleIterator};
 
 macro_rules! empty_nodes {
     () => (
@@ -54,11 +54,11 @@ pub type FixedMemoryTrie<K, V> = FixedTrie<HashMap<H256, Vec<u8>>, K, V>;
 pub type FixedMemorySecureTrie<K, V> = FixedSecureTrie<HashMap<H256, Vec<u8>>, K, V>;
 
 #[derive(Clone, Debug)]
-pub struct FixedTrie<D: DatabaseGuard, K: rlp::Encodable, V: rlp::Encodable + rlp::Decodable>(
+pub struct FixedTrie<D: DatabaseGuard, K: rlp::Encodable + rlp::Decodable, V: rlp::Encodable + rlp::Decodable>(
     Trie<D>, PhantomData<(K, V)>
 );
 
-impl<D: DatabaseGuard, K: rlp::Encodable, V: rlp::Encodable + rlp::Decodable> FixedTrie<D, K, V> {
+impl<D: DatabaseGuard, K: rlp::Encodable + rlp::Decodable, V: rlp::Encodable + rlp::Decodable> FixedTrie<D, K, V> {
     pub fn new(trie: Trie<D>) -> Self {
         FixedTrie(trie, PhantomData)
     }
@@ -84,6 +84,10 @@ impl<D: DatabaseGuard, K: rlp::Encodable, V: rlp::Encodable + rlp::Decodable> Fi
 
     pub fn remove(&mut self, key: &K) {
         self.0.remove(key)
+    }
+
+    pub fn iter(&self) -> FixedMerkleIterator<D, K, V> {
+        FixedMerkleIterator::new(self.0.iter())
     }
 }
 

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -18,6 +18,7 @@ use self::cache::Cache;
 use self::database::{Change, ChangeSet};
 
 pub use self::database::{Database, DatabaseOwned, DatabaseGuard, MemoryDatabase, MemoryDatabaseGuard};
+pub use self::iter::MerkleIterator;
 
 macro_rules! empty_nodes {
     () => (
@@ -179,6 +180,15 @@ impl<D: DatabaseGuard> Trie<D> {
         Self {
             database,
             root
+        }
+    }
+
+    pub fn iter(&self) -> MerkleIterator<D> {
+        if self.root == empty_trie_hash!() {
+            MerkleIterator::empty(&self.database)
+        } else {
+            let value = self.database.get(self.root).unwrap();
+            MerkleIterator::new(&self.database, value)
         }
     }
 

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -45,6 +45,7 @@ macro_rules! empty_trie_hash {
 pub mod merkle;
 mod cache;
 mod database;
+mod iter;
 
 pub type MemorySecureTrie = SecureTrie<HashMap<H256, Vec<u8>>>;
 pub type MemoryTrie = Trie<HashMap<H256, Vec<u8>>>;

--- a/trie/src/merkle/nibble.rs
+++ b/trie/src/merkle/nibble.rs
@@ -85,6 +85,21 @@ pub fn from_key(key: &[u8]) -> NibbleVec {
     vec
 }
 
+pub fn into_key(nibble: NibbleSlice) -> Vec<u8> {
+    let mut ret = Vec::new();
+
+    for i in 0..nibble.len() {
+        if i & 1 == 0 { // even
+            let value: u8 = nibble[i].into();
+            ret.push(value << 4);
+        } else {
+            ret[i / 2] |= nibble[i].into();
+        }
+    }
+
+    ret
+}
+
 pub fn decode(rlp: &Rlp) -> (NibbleVec, NibbleType) {
     let mut vec = NibbleVec::new();
 
@@ -173,4 +188,16 @@ pub fn common_all<'a, T: Iterator<Item=NibbleSlice<'a>>>(mut iter: T) -> NibbleS
     }
 
     common_cur
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_into_key() {
+        let key = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 244, 233, 188];
+
+        assert_eq!(key, into_key(&from_key(&key)));
+    }
 }


### PR DESCRIPTION
This implements MerkleIterator and FixedMerkleIterator for traversal inside a trie.

Note that secure tries are not traversable, so they need fat database.