### PR TITLE
 block: Block::is_basic_valid 

### DIFF
--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.3.0"
+version = "0.3.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/src/block.rs
+++ b/block/src/block.rs
@@ -35,6 +35,20 @@ pub struct Block {
     pub ommers: Vec<Header>,
 }
 
+impl Block {
+    pub fn is_basic_valid(&self) -> bool {
+        if transactions_root(&self.transactions) != self.header.transactions_root {
+            return false;
+        }
+
+        if ommers_hash(&self.ommers) != self.header.ommers_hash {
+            return false;
+        }
+
+        return true;
+    }
+}
+
 impl Encodable for Block {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.begin_list(3);


### PR DESCRIPTION
Most of the block parameters require either parent block or SputnikVM to check validity. So `is_basic_valid` only checks things that don't require them, that is, the transactions_root and the ommers_hash.