### PR TITLE
Update blockchain dependency to v0.2

### DIFF
--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."
@@ -16,7 +16,7 @@ etcommon-bigint = { version = "0.2", path = "../bigint" }
 etcommon-rlp = { version = "0.2", path = "../rlp" }
 etcommon-bloom = { version = "0.2", path = "../bloom" }
 etcommon-trie = { version = "0.3", path = "../trie" }
-blockchain = "0.1"
+blockchain = "0.2"
 
 [dev-dependencies]
 rand = "0.3.12"

--- a/block/src/header.rs
+++ b/block/src/header.rs
@@ -26,7 +26,7 @@ impl TotalHeader {
 }
 
 impl HeaderHash<H256> for TotalHeader {
-    fn parent_hash(&self) -> H256 {
+    fn parent_hash(&self) -> Option<H256> {
         self.0.parent_hash()
     }
 
@@ -73,8 +73,12 @@ pub struct Header {
 }
 
 impl HeaderHash<H256> for Header {
-    fn parent_hash(&self) -> H256 {
-        self.parent_hash
+    fn parent_hash(&self) -> Option<H256> {
+        if self.number == U256::zero() {
+            None
+        } else {
+            Some(self.parent_hash)
+        }
     }
 
     fn header_hash(&self) -> H256 {


### PR DESCRIPTION
HeaderHash::parent_hash is changed to Option<H>. This is due to that
in genesis block, its parent hash value is meaningless.

This is important for implementing things like last_hashes without
knowing the Ethereum detals.