### PR TITLE
no_std support for rlp, bigint, and hexutil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ matrix:
     - rust: nightly
 script:
   - cargo test --all
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd rlp && cargo build --no-default-features; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd hexutil && cargo build --no-default-features; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd rlp && cargo build --no-default-features && cd ..; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd hexutil && cargo build --no-default-features && cd ..; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
   - cargo test --all
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd rlp && cargo build --no-default-features && cd ..; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd hexutil && cargo build --no-default-features && cd ..; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd bigint && cargo build --no-default-features && cd ..; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ matrix:
     - rust: nightly
 script:
   - cargo test --all
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd rlp && cargo build --no-default-features; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd hexutil && cargo build --no-default-features; fi

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -5,19 +5,22 @@ license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Big integer (256-bit and 512-bit) implementation for SputnikVM and other Ethereum Classic clients."
 repository = "https://github.com/ethereumproject/etcommon-rs"
+keywords = ["no_std"]
 
 [lib]
 name = "bigint"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-byteorder = "1.0"
-rand = "0.3.12"
-libc = "0.2"
-etcommon-rlp = { version = "0.2", path = "../rlp" }
-etcommon-hexutil = { version = "0.2", path = "../hexutil" }
+byteorder = { version = "1.0", default-features = false }
+rand = { version = "0.3.12", optional = true }
+libc = { version = "0.2", optional = true }
+etcommon-rlp = { version = "0.2", path = "../rlp", default-features = false }
+etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }
 
 [features]
+default = ["std"]
 heapsizeof = ["heapsize"]
 x64asm_arithmetic=[]
 rust_arithmetic=[]
+std = [ "byteorder/std", "rand", "libc", "etcommon-rlp/std", "etcommon-hexutil/std" ]

--- a/bigint/src/gas.rs
+++ b/bigint/src/gas.rs
@@ -4,10 +4,16 @@
 use super::{M256, U256};
 use hexutil::ParseHexError;
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-use std::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
-use std::cmp::Ordering;
-use std::str::FromStr;
-use std::fmt;
+
+#[cfg(feature = "std")] use std::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
+#[cfg(feature = "std")] use std::cmp::Ordering;
+#[cfg(feature = "std")] use std::str::FromStr;
+#[cfg(feature = "std")] use std::fmt;
+
+#[cfg(not(feature = "std"))] use core::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
+#[cfg(not(feature = "std"))] use core::cmp::Ordering;
+#[cfg(not(feature = "std"))] use core::str::FromStr;
+#[cfg(not(feature = "std"))] use core::fmt;
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
 pub struct Gas(U256);

--- a/bigint/src/hash/rlp.rs
+++ b/bigint/src/hash/rlp.rs
@@ -1,5 +1,6 @@
 use super::{H64, H128, H160, H256, H512, H520, H2048};
-use std::{cmp, mem, str};
+#[cfg(feature = "std")] use std::{cmp, mem, str};
+#[cfg(not(feature = "std"))] use core::{cmp, mem, str};
 use rlp::{RlpStream, Encodable, Decodable, DecoderError, UntrustedRlp};
 
 macro_rules! impl_encodable_for_hash {

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -1,8 +1,17 @@
 #![cfg_attr(asm_available, feature(asm))]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 extern crate rlp;
 extern crate hexutil;
+#[cfg(feature = "std")]
 extern crate rand;
+#[cfg(feature = "std")]
 extern crate libc;
 extern crate byteorder;
 

--- a/bigint/src/m256.rs
+++ b/bigint/src/m256.rs
@@ -1,10 +1,16 @@
 //! Unsigned modulo 256-bit integer
 
-use std::convert::{From, Into};
-use std::str::FromStr;
-use std::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
-use std::cmp::Ordering;
-use std::fmt;
+#[cfg(feature = "std")] use std::convert::{From, Into};
+#[cfg(feature = "std")] use std::str::FromStr;
+#[cfg(feature = "std")] use std::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
+#[cfg(feature = "std")] use std::cmp::Ordering;
+#[cfg(feature = "std")] use std::fmt;
+
+#[cfg(not(feature = "std"))] use core::convert::{From, Into};
+#[cfg(not(feature = "std"))] use core::str::FromStr;
+#[cfg(not(feature = "std"))] use core::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
+#[cfg(not(feature = "std"))] use core::cmp::Ordering;
+#[cfg(not(feature = "std"))] use core::fmt;
 
 use hexutil::ParseHexError;
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};

--- a/bigint/src/mi256.rs
+++ b/bigint/src/mi256.rs
@@ -1,8 +1,12 @@
 //! Signed modulo 256-bit integer
 
-use std::convert::{From, Into};
-use std::ops::{Div, Rem};
-use std::cmp::Ordering;
+#[cfg(feature = "std")] use std::convert::{From, Into};
+#[cfg(feature = "std")] use std::ops::{Div, Rem};
+#[cfg(feature = "std")] use std::cmp::Ordering;
+
+#[cfg(not(feature = "std"))] use core::convert::{From, Into};
+#[cfg(not(feature = "std"))] use core::ops::{Div, Rem};
+#[cfg(not(feature = "std"))] use core::cmp::Ordering;
 
 use super::{Sign, M256, U256};
 

--- a/bigint/src/uint/mod.rs
+++ b/bigint/src/uint/mod.rs
@@ -29,10 +29,19 @@
 //! implementations for even more speed, hidden behind the `x64_arithmetic`
 //! feature flag.
 
-use std::{fmt, cmp};
-use std::str::{FromStr};
-use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub, Index};
-use std::cmp::Ordering;
+#[cfg(feature = "std")] use std::{fmt, cmp};
+#[cfg(feature = "std")] use std::str::{FromStr};
+#[cfg(feature = "std")] use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub, Index};
+#[cfg(feature = "std")] use std::cmp::Ordering;
+
+#[cfg(not(feature = "std"))] use core::{fmt, cmp};
+#[cfg(not(feature = "std"))] use core::str::{FromStr};
+#[cfg(not(feature = "std"))] use core::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub, Index};
+#[cfg(not(feature = "std"))] use core::cmp::Ordering;
+
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+
 use byteorder::{ByteOrder, BigEndian, LittleEndian};
 use hexutil::{ParseHexError, read_hex, clean_0x};
 
@@ -563,7 +572,12 @@ macro_rules! construct_uint {
 			/// Panics if the number is larger than usize::max_value().
             #[inline]
             pub fn as_usize(&self) -> usize {
+                #[cfg(feature = "std")]
                 use std::mem::size_of;
+
+                #[cfg(not(feature = "std"))]
+                use core::mem::size_of;
+
                 if size_of::<usize>() > size_of::<u64>() && size_of::<usize>() < size_of::<u32>() {
                     panic!("Unsupported platform")
                 }

--- a/bigint/src/uint/rlp.rs
+++ b/bigint/src/uint/rlp.rs
@@ -8,7 +8,8 @@
 // except according to those terms.
 
 use super::{U256, U128};
-use std::{cmp, mem, str};
+#[cfg(feature = "std")] use std::{cmp, mem, str};
+#[cfg(not(feature = "std"))] use core::{cmp, mem, str};
 use rlp::{RlpStream, Encodable, Decodable, DecoderError, UntrustedRlp};
 
 macro_rules! impl_encodable_for_uint {

--- a/hexutil/Cargo.toml
+++ b/hexutil/Cargo.toml
@@ -8,3 +8,7 @@ repository = "https://github.com/ethereumproject/etcommon-rs"
 
 [lib]
 name = "hexutil"
+
+[features]
+default = ["std"]
+std = []

--- a/hexutil/Cargo.toml
+++ b/hexutil/Cargo.toml
@@ -5,6 +5,7 @@ license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Hex helper functions."
 repository = "https://github.com/ethereumproject/etcommon-rs"
+keywords = ["no_std"]
 
 [lib]
 name = "hexutil"

--- a/hexutil/src/lib.rs
+++ b/hexutil/src/lib.rs
@@ -1,4 +1,18 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 use std::fmt::Write;
+
+#[cfg(not(feature = "std"))]
+use core::fmt::Write;
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 #[derive(Debug)]
 /// Errors exhibited from `read_hex`.

--- a/nightly.nix
+++ b/nightly.nix
@@ -13,12 +13,12 @@ let pkgs = (
       (import (builtins.toPath "${rustOverlay}/rust-overlay.nix"))
       (self: super: {
         rust = {
-          rustc = super.rustChannels.stable.rust;
-          cargo = super.rustChannels.stable.cargo;
+          rustc = super.rustChannels.nightly.rust;
+          cargo = super.rustChannels.nightly.cargo;
         };
         rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform {
-          rustc = super.rustChannels.stable.rust;
-          cargo = super.rustChannels.stable.cargo;
+          rustc = super.rustChannels.nightly.rust;
+          cargo = super.rustChannels.nightly.cargo;
         });
       })
     ];

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -10,7 +10,11 @@ authors = ["Parity Technologies <admin@parity.io>"]
 name = "rlp"
 
 [dependencies]
-elastic-array-plus = "0.9.0"
-lazy_static = "0.2"
-byteorder = "1.0"
-etcommon-hexutil = { version = "0.2", path = "../hexutil" }
+elastic-array-plus = { version = "0.9.1", default-features = false }
+lazy_static = { version = "0.2", optional = true }
+byteorder = { version = "1.0", default-features = false }
+etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }
+
+[features]
+default = ["std"]
+std = ["etcommon-hexutil/std", "byteorder/std", "lazy_static", "elastic-array-plus/std"]

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -4,7 +4,8 @@ description = "Recursive-length prefix encoding, decoding, and compression"
 repository = "https://github.com/ethereumproject/etcommon-rs"
 license = "MIT/Apache-2.0"
 version = "0.2.2"
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = ["Parity Technologies <admin@parity.io>", "Wei Tang <hi@that.world>"]
+keywords = ["no_std"]
 
 [lib]
 name = "rlp"

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -12,5 +12,5 @@ name = "rlp"
 [dependencies]
 elastic-array-plus = "0.9.0"
 lazy_static = "0.2"
-rustc-serialize = "0.3"
 byteorder = "1.0"
+etcommon-hexutil = { version = "0.2", path = "../hexutil" }

--- a/rlp/src/common.rs
+++ b/rlp/src/common.rs
@@ -10,11 +10,13 @@
 
 use compression::InvalidRlpSwapper;
 
+#[cfg(feature = "std")]
 lazy_static! {
 	/// Swapper for snapshot compression.
 	pub static ref SNAPSHOT_RLP_SWAPPER: InvalidRlpSwapper<'static> = InvalidRlpSwapper::new(EMPTY_RLPS, INVALID_RLPS);
 }
 
+#[cfg(feature = "std")]
 lazy_static! {
 	/// Swapper with common long RLPs, up to 127 can be added.
 	pub static ref BLOCKS_RLP_SWAPPER: InvalidRlpSwapper<'static> = InvalidRlpSwapper::new(COMMON_RLPS, INVALID_RLPS);

--- a/rlp/src/compression.rs
+++ b/rlp/src/compression.rs
@@ -6,15 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+#[cfg(feature = "std")] use std::collections::{HashMap as Map};
+#[cfg(not(feature = "std"))] use alloc::{BTreeMap as Map};
 use elastic_array::ElasticArray1024;
+#[cfg(feature = "std")]
 use common::{BLOCKS_RLP_SWAPPER, SNAPSHOT_RLP_SWAPPER};
 use {UntrustedRlp, Compressible, encode, RlpStream};
 
 /// Stores RLPs used for compression
 pub struct InvalidRlpSwapper<'a> {
-	invalid_to_valid: HashMap<&'a [u8], &'a [u8]>,
-	valid_to_invalid: HashMap<&'a [u8], &'a [u8]>,
+	invalid_to_valid: Map<&'a [u8], &'a [u8]>,
+	valid_to_invalid: Map<&'a [u8], &'a [u8]>,
 }
 
 impl<'a> InvalidRlpSwapper<'a> {
@@ -23,8 +25,8 @@ impl<'a> InvalidRlpSwapper<'a> {
 		if rlps_to_swap.len() > 0x7e {
 			panic!("Invalid usage, only 127 RLPs can be swappable.");
 		}
-		let mut invalid_to_valid = HashMap::new();
-		let mut valid_to_invalid = HashMap::new();
+		let mut invalid_to_valid = Map::new();
+		let mut valid_to_invalid = Map::new();
 		for (&rlp, &invalid) in rlps_to_swap.iter().zip(invalid_rlps.iter()) {
 			invalid_to_valid.insert(invalid, rlp);
 			valid_to_invalid.insert(rlp, invalid);
@@ -140,6 +142,7 @@ fn deep_decompress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<El
   	}
 }
 
+#[cfg(feature = "std")]
 impl<'a> Compressible for UntrustedRlp<'a> {
 	type DataType = RlpType;
 

--- a/rlp/src/error.rs
+++ b/rlp/src/error.rs
@@ -6,7 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt;
+#[cfg(feature = "std")] use std::fmt;
+#[cfg(not(feature = "std"))] use core::fmt;
+
+#[cfg(feature = "std")]
 use std::error::Error as StdError;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -34,6 +37,7 @@ pub enum DecoderError {
 	Custom(&'static str),
 }
 
+#[cfg(feature = "std")]
 impl StdError for DecoderError {
 	fn description(&self) -> &str {
 		"builder error"

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -6,7 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cmp, mem, str};
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+
+#[cfg(feature = "std")] use std::{cmp, mem, str};
+#[cfg(not(feature = "std"))] use core::{cmp, mem, str};
 use byteorder::{ByteOrder, BigEndian};
 use traits::{Encodable, Decodable};
 use stream::RlpStream;
@@ -220,6 +224,9 @@ impl Encodable for String {
 
 impl Decodable for String {
 	fn decode(rlp: &UntrustedRlp) -> Result<Self, DecoderError> {
+        #[cfg(not(feature = "std"))]
+        use alloc::borrow::ToOwned;
+
 		rlp.decoder().decode_value(|bytes| {
 			match str::from_utf8(bytes) {
 				Ok(s) => Ok(s.to_owned()),

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -6,6 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
 //! Recursive Length Prefix serialization crate.
 //!
 //! Allows encoding, decoding, and view onto rlp-slice
@@ -42,6 +45,10 @@ extern crate byteorder;
 extern crate elastic_array;
 extern crate hexutil;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate lazy_static;
 
@@ -54,7 +61,12 @@ mod compression;
 mod common;
 mod impls;
 
-use std::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+
+#[cfg(feature = "std")] use std::borrow::Borrow;
+#[cfg(not(feature = "std"))] use core::borrow::Borrow;
+
 use elastic_array::ElasticArray1024;
 
 pub use error::DecoderError;

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -40,7 +40,7 @@
 
 extern crate byteorder;
 extern crate elastic_array;
-extern crate rustc_serialize;
+extern crate hexutil;
 
 #[macro_use]
 extern crate lazy_static;

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -6,7 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt;
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+
+#[cfg(feature = "std")] use std::fmt;
+#[cfg(not(feature = "std"))] use core::fmt;
 use {UntrustedRlp, PayloadInfo, Prototype, Decodable};
 
 impl<'a> From<UntrustedRlp<'a>> for Rlp<'a> {

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -6,7 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+
+#[cfg(feature = "std")] use std::borrow::Borrow;
+#[cfg(not(feature = "std"))] use core::borrow::Borrow;
 use byteorder::{ByteOrder, BigEndian};
 use elastic_array::{ElasticArray16, ElasticArray1024};
 use traits::Encodable;

--- a/rlp/src/untrusted_rlp.rs
+++ b/rlp/src/untrusted_rlp.rs
@@ -6,8 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cell::Cell;
-use std::fmt;
+#[cfg(not(feature = "std"))]
+use alloc::{String, Vec};
+
+#[cfg(feature = "std")] use std::cell::Cell;
+#[cfg(feature = "std")] use std::fmt;
+#[cfg(not(feature = "std"))] use core::cell::Cell;
+#[cfg(not(feature = "std"))] use core::fmt;
 use impls::decode_usize;
 use hexutil::to_hex;
 use {Decodable, DecoderError};

--- a/rlp/src/untrusted_rlp.rs
+++ b/rlp/src/untrusted_rlp.rs
@@ -8,8 +8,8 @@
 
 use std::cell::Cell;
 use std::fmt;
-use rustc_serialize::hex::ToHex;
 use impls::decode_usize;
+use hexutil::to_hex;
 use {Decodable, DecoderError};
 
 /// rlp offset
@@ -118,7 +118,7 @@ impl<'a> fmt::Display for UntrustedRlp<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
 		match self.prototype() {
 			Ok(Prototype::Null) => write!(f, "null"),
-			Ok(Prototype::Data(_)) => write!(f, "\"0x{}\"", self.data().unwrap().to_hex()),
+			Ok(Prototype::Data(_)) => write!(f, "\"{}\"", &to_hex(self.data().unwrap())),
 			Ok(Prototype::List(len)) => {
 				write!(f, "[")?;
 				for i in 0..len-1 {
@@ -386,11 +386,11 @@ impl<'a> BasicDecoder<'a> {
 #[cfg(test)]
 mod tests {
 	use UntrustedRlp;
+    use hexutil::read_hex;
 
 	#[test]
 	fn test_rlp_display() {
-		use rustc_serialize::hex::FromHex;
-		let data = "f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470".from_hex().unwrap();
+		let data = read_hex("f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").unwrap();
 		let rlp = UntrustedRlp::new(&data);
 		assert_eq!(format!("{}", rlp), "[\"0x05\", \"0x010efbef67941f79b2\", \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"]");
 	}


### PR DESCRIPTION
This adds back no_std support for rlp, bigint and hexutil.