### PR TITLE
Make rlp and hexutil dependency optional for bigint

### DIFF
--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -15,12 +15,13 @@ heapsize = { version = "0.4", optional = true }
 byteorder = { version = "1.0", default-features = false }
 rand = { version = "0.3.12", optional = true }
 libc = { version = "0.2", optional = true }
-etcommon-rlp = { version = "0.2", path = "../rlp", default-features = false }
+etcommon-rlp = { version = "0.2", path = "../rlp", default-features = false, optional = true }
 etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "rlp"]
 heapsizeof = ["heapsize"]
-x64asm_arithmetic=[]
-rust_arithmetic=[]
-std = [ "byteorder/std", "rand", "libc", "etcommon-rlp/std", "etcommon-hexutil/std" ]
+x64asm_arithmetic = []
+rust_arithmetic = []
+rlp = ["etcommon-rlp"]
+std = ["byteorder/std", "rand", "libc", "etcommon-rlp/std", "etcommon-hexutil/std"]

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-bigint"
-version = "0.2.8"
+version = "0.2.9"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Big integer (256-bit and 512-bit) implementation for SputnikVM and other Ethereum Classic clients."

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -16,12 +16,13 @@ byteorder = { version = "1.0", default-features = false }
 rand = { version = "0.3.12", optional = true }
 libc = { version = "0.2", optional = true }
 etcommon-rlp = { version = "0.2", path = "../rlp", default-features = false, optional = true }
-etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }
+etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false, optional = true }
 
 [features]
-default = ["std", "rlp"]
+default = ["std", "rlp", "string"]
 heapsizeof = ["heapsize"]
 x64asm_arithmetic = []
 rust_arithmetic = []
 rlp = ["etcommon-rlp"]
+string = ["etcommon-hexutil"]
 std = ["byteorder/std", "rand", "libc", "etcommon-rlp/std", "etcommon-hexutil/std"]

--- a/bigint/src/bytes.rs
+++ b/bigint/src/bytes.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rlp")]
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 
 /// Maximum 256-bit byte-array that does not require heap allocation.
@@ -21,12 +22,14 @@ impl Default for B256 {
     }
 }
 
+#[cfg(feature = "rlp")]
 impl Encodable for B256 {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.encoder().encode_value(&self.1[0..self.0])
     }
 }
 
+#[cfg(feature = "rlp")]
 impl Decodable for B256 {
     fn decode(rlp: &UntrustedRlp) -> Result<Self, DecoderError> {
         rlp.decoder().decode_value(|bytes| {

--- a/bigint/src/gas.rs
+++ b/bigint/src/gas.rs
@@ -2,16 +2,17 @@
 //! impossible to obtain this number during a block formation.
 
 use super::{M256, U256};
+#[cfg(feature = "string")]
 use hexutil::ParseHexError;
 #[cfg(feature = "rlp")]
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 
-#[cfg(feature = "std")] use std::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
+#[cfg(feature = "std")] use std::ops::{Add, Sub, Mul, Div, Rem};
 #[cfg(feature = "std")] use std::cmp::Ordering;
 #[cfg(feature = "std")] use std::str::FromStr;
 #[cfg(feature = "std")] use std::fmt;
 
-#[cfg(not(feature = "std"))] use core::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
+#[cfg(not(feature = "std"))] use core::ops::{Add, Sub, Mul, Div, Rem};
 #[cfg(not(feature = "std"))] use core::cmp::Ordering;
 #[cfg(not(feature = "std"))] use core::str::FromStr;
 #[cfg(not(feature = "std"))] use core::fmt;
@@ -60,6 +61,7 @@ impl Gas {
 
 impl Default for Gas { fn default() -> Gas { Gas::zero() } }
 
+#[cfg(feature = "string")]
 impl FromStr for Gas {
     type Err = ParseHexError;
 

--- a/bigint/src/gas.rs
+++ b/bigint/src/gas.rs
@@ -3,6 +3,7 @@
 
 use super::{M256, U256};
 use hexutil::ParseHexError;
+#[cfg(feature = "rlp")]
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 
 #[cfg(feature = "std")] use std::ops::{Add, Sub, Not, Mul, Div, Shr, Shl, BitAnd, BitOr, BitXor, Rem};
@@ -67,12 +68,14 @@ impl FromStr for Gas {
     }
 }
 
+#[cfg(feature = "rlp")]
 impl Encodable for Gas {
     fn rlp_append(&self, s: &mut RlpStream) {
         self.0.rlp_append(s);
     }
 }
 
+#[cfg(feature = "rlp")]
 impl Decodable for Gas {
     fn decode(rlp: &UntrustedRlp) -> Result<Self, DecoderError> {
         Ok(Gas(U256::decode(rlp)?))

--- a/bigint/src/hash/mod.rs
+++ b/bigint/src/hash/mod.rs
@@ -11,8 +11,8 @@
 #[cfg(feature = "rlp")]
 mod rlp;
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(all(not(feature = "std"), feature = "string"))]
+use alloc::String;
 
 #[cfg(feature = "std")] use std::{ops, fmt, cmp};
 #[cfg(feature = "std")] use std::cmp::{min, Ordering};
@@ -27,12 +27,12 @@ use alloc::{String, Vec};
 #[cfg(not(feature = "std"))] use core::{ops, fmt, cmp};
 #[cfg(not(feature = "std"))] use core::cmp::{min, Ordering};
 #[cfg(not(feature = "std"))] use core::ops::{Deref, DerefMut, BitXor, BitAnd, BitOr, IndexMut, Index};
-#[cfg(not(feature = "std"))] use core::hash::{Hash, Hasher, BuildHasherDefault};
-#[cfg(not(feature = "std"))] use alloc::{BTreeMap as Map, BTreeSet as Set};
+#[cfg(not(feature = "std"))] use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))] use core::str::FromStr;
-#[cfg(not(feature = "std"))] use alloc::borrow::ToOwned;
+#[cfg(all(not(feature = "std"), feature = "string"))] use alloc::borrow::ToOwned;
 
 use super::U256;
+#[cfg(feature = "string")]
 use hexutil::{read_hex, ParseHexError, clean_0x};
 use byteorder::{ByteOrder, BigEndian};
 
@@ -150,6 +150,7 @@ macro_rules! impl_hash {
 			}
 		}
 
+        #[cfg(feature = "string")]
 		impl FromStr for $from {
 			type Err = ParseHexError;
 
@@ -368,6 +369,7 @@ macro_rules! impl_hash {
 			}
 		}
 
+        #[cfg(feature = "string")]
 		impl $from {
 			/// Get a hex representation.
 			pub fn hex(&self) -> String {
@@ -392,6 +394,7 @@ macro_rules! impl_hash {
 			}
 		}
 
+        #[cfg(feature = "string")]
 		impl From<&'static str> for $from {
 			fn from(s: &'static str) -> $from {
 				let s = clean_0x(s);

--- a/bigint/src/hash/mod.rs
+++ b/bigint/src/hash/mod.rs
@@ -8,6 +8,7 @@
 
 //! General hash types, a fixed-size raw-data type used as the output of hash functions.
 
+#[cfg(feature = "rlp")]
 mod rlp;
 
 #[cfg(not(feature = "std"))]

--- a/bigint/src/hash/rlp.rs
+++ b/bigint/src/hash/rlp.rs
@@ -1,6 +1,6 @@
 use super::{H64, H128, H160, H256, H512, H520, H2048};
-#[cfg(feature = "std")] use std::{cmp, mem, str};
-#[cfg(not(feature = "std"))] use core::{cmp, mem, str};
+#[cfg(feature = "std")] use std::cmp;
+#[cfg(not(feature = "std"))] use core::cmp;
 use rlp::{RlpStream, Encodable, Decodable, DecoderError, UntrustedRlp};
 
 macro_rules! impl_encodable_for_hash {

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -1,14 +1,20 @@
+#![deny(unused_import_braces,
+        unused_comparisons, unused_must_use,
+        unused_variables, non_shorthand_field_patterns,
+        unreachable_code)]
+
 #![cfg_attr(asm_available, feature(asm))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
+#![cfg_attr(all(not(feature = "std"), feature = "string"), feature(alloc))]
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "string"))]
 #[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "rlp")]
 extern crate rlp;
+#[cfg(feature = "string")]
 extern crate hexutil;
 #[cfg(feature = "std")]
 extern crate rand;

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(feature = "rlp")]
 extern crate rlp;
 extern crate hexutil;
 #[cfg(feature = "std")]

--- a/bigint/src/m256.rs
+++ b/bigint/src/m256.rs
@@ -13,6 +13,7 @@
 #[cfg(not(feature = "std"))] use core::fmt;
 
 use hexutil::ParseHexError;
+#[cfg(feature = "rlp")]
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 use super::{U512, U256, H256, H160};
 
@@ -87,12 +88,14 @@ impl FromStr for M256 {
     }
 }
 
+#[cfg(feature = "rlp")]
 impl Encodable for M256 {
     fn rlp_append(&self, s: &mut RlpStream) {
         self.0.rlp_append(s);
     }
 }
 
+#[cfg(feature = "rlp")]
 impl Decodable for M256 {
     fn decode(rlp: &UntrustedRlp) -> Result<Self, DecoderError> {
         Ok(M256(U256::decode(rlp)?))

--- a/bigint/src/m256.rs
+++ b/bigint/src/m256.rs
@@ -12,6 +12,7 @@
 #[cfg(not(feature = "std"))] use core::cmp::Ordering;
 #[cfg(not(feature = "std"))] use core::fmt;
 
+#[cfg(feature = "string")]
 use hexutil::ParseHexError;
 #[cfg(feature = "rlp")]
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
@@ -80,6 +81,7 @@ impl M256 {
 
 impl Default for M256 { fn default() -> M256 { M256::zero() } }
 
+#[cfg(feature = "string")]
 impl FromStr for M256 {
     type Err = ParseHexError;
 

--- a/bigint/src/uint/mod.rs
+++ b/bigint/src/uint/mod.rs
@@ -45,6 +45,7 @@ use alloc::{String, Vec};
 use byteorder::{ByteOrder, BigEndian, LittleEndian};
 use hexutil::{ParseHexError, read_hex, clean_0x};
 
+#[cfg(feature = "rlp")]
 mod rlp;
 
 /// Conversion from decimal string error

--- a/bigint/src/uint/mod.rs
+++ b/bigint/src/uint/mod.rs
@@ -29,21 +29,22 @@
 //! implementations for even more speed, hidden behind the `x64_arithmetic`
 //! feature flag.
 
-#[cfg(feature = "std")] use std::{fmt, cmp};
-#[cfg(feature = "std")] use std::str::{FromStr};
-#[cfg(feature = "std")] use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub, Index};
+#[cfg(feature = "std")] use std::fmt;
+#[cfg(feature = "std")] use std::str::FromStr;
+#[cfg(feature = "std")] use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub};
 #[cfg(feature = "std")] use std::cmp::Ordering;
 
-#[cfg(not(feature = "std"))] use core::{fmt, cmp};
-#[cfg(not(feature = "std"))] use core::str::{FromStr};
-#[cfg(not(feature = "std"))] use core::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub, Index};
+#[cfg(not(feature = "std"))] use core::fmt;
+#[cfg(not(feature = "std"))] use core::str::FromStr;
+#[cfg(not(feature = "std"))] use core::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub};
 #[cfg(not(feature = "std"))] use core::cmp::Ordering;
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(all(not(feature = "std"), feature = "string"))]
+use alloc::String;
 
 use byteorder::{ByteOrder, BigEndian, LittleEndian};
-use hexutil::{ParseHexError, read_hex, clean_0x};
+#[cfg(feature = "string")]
+use hexutil::{ParseHexError, read_hex};
 
 #[cfg(feature = "rlp")]
 mod rlp;
@@ -890,6 +891,7 @@ macro_rules! construct_uint {
 			}
 		}
 
+        #[cfg(feature = "string")]
 		impl FromStr for $name {
 			type Err = ParseHexError;
 
@@ -1116,16 +1118,15 @@ macro_rules! construct_uint {
 					return write!(f, "0");
 				}
 
-				let mut s = String::new();
 				let mut current = *self;
 				let ten = $name::from(10);
 
 				while !current.is_zero() {
-					s = format!("{}{}", (current % ten).low_u32(), s);
+					write!(f, "{}", (current % ten).low_u32())?;
 					current = current / ten;
 				}
 
-				write!(f, "{}", s)
+                Ok(())
 			}
 		}
 
@@ -1163,6 +1164,7 @@ macro_rules! construct_uint {
 		    }
 		}
 
+        #[cfg(feature = "string")]
 		impl From<&'static str> for $name {
 			fn from(s: &'static str) -> Self {
 				s.parse().unwrap()

--- a/bigint/src/uint/mod.rs
+++ b/bigint/src/uint/mod.rs
@@ -1118,13 +1118,20 @@ macro_rules! construct_uint {
 					return write!(f, "0");
 				}
 
+                let mut s = [0u8; $n_words * 20];
+                let mut i = $n_words * 20;
 				let mut current = *self;
 				let ten = $name::from(10);
 
 				while !current.is_zero() {
-					write!(f, "{}", (current % ten).low_u32())?;
+                    i = i - 1;
+                    s[i] = (current % ten).low_u32() as u8;
 					current = current / ten;
 				}
+
+                for i in i..($n_words * 20) {
+                    write!(f, "{}", s[i])?;
+                }
 
                 Ok(())
 			}

--- a/bigint/src/uint/rlp.rs
+++ b/bigint/src/uint/rlp.rs
@@ -8,8 +8,6 @@
 // except according to those terms.
 
 use super::{U256, U128};
-#[cfg(feature = "std")] use std::{cmp, mem, str};
-#[cfg(not(feature = "std"))] use core::{cmp, mem, str};
 use rlp::{RlpStream, Encodable, Decodable, DecoderError, UntrustedRlp};
 
 macro_rules! impl_encodable_for_uint {

--- a/block-core/Cargo.toml
+++ b/block-core/Cargo.toml
@@ -12,7 +12,7 @@ name = "block_core"
 
 [dependencies]
 sha3 = "0.6"
-etcommon-bigint = { version = "0.2", path = "../bigint", default-features = false, features = ["rlp"] }
+etcommon-bigint = { version = "0.2", path = "../bigint", default-features = false, features = ["rlp", "string"] }
 etcommon-rlp = { version = "0.2", path = "../rlp", default-features = false }
 
 [dev-dependencies]

--- a/block-core/Cargo.toml
+++ b/block-core/Cargo.toml
@@ -12,7 +12,7 @@ name = "block_core"
 
 [dependencies]
 sha3 = "0.6"
-etcommon-bigint = { version = "0.2", path = "../bigint", default-features = false }
+etcommon-bigint = { version = "0.2", path = "../bigint", default-features = false, features = ["rlp"] }
 etcommon-rlp = { version = "0.2", path = "../rlp", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This allows the bigint create to be built on `no_std` by Rust stable, needed for some future crates.