### PR TITLE
block: add libsecp256k1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd hexutil && cargo build --no-default-features && cd ..; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd bigint && cargo build --no-default-features && cd ..; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd block-core && cargo build --no-default-features && cd ..; fi
+  - cd block && cargo build --no-default-features --features rust-secp256k1 && cd ..

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.3.3"
+version = "0.3.4"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -11,7 +11,6 @@ name = "block"
 
 [dependencies]
 sha3 = "0.6"
-secp256k1-plus = "0.5"
 etcommon-block-core = { version = "0.1", path = "../block-core" }
 etcommon-bigint = { version = "0.2", path = "../bigint" }
 etcommon-rlp = { version = "0.2", path = "../rlp" }
@@ -19,6 +18,14 @@ etcommon-bloom = { version = "0.2", path = "../bloom" }
 etcommon-trie = { version = "0.3", path = "../trie" }
 blockchain = "0.2"
 
+secp256k1-plus = { version = "0.5", optional = true }
+libsecp256k1 = { version = "0.1", optional = true }
+
 [dev-dependencies]
 rand = "0.3.12"
 etcommon-hexutil = "0.2"
+
+[features]
+default = ["c-secp256k1"]
+c-secp256k1 = ["secp256k1-plus"]
+rust-secp256k1 = ["libsecp256k1"]

--- a/block/src/address.rs
+++ b/block/src/address.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "c-secp256k1")]
 use secp256k1::{SECP256K1, Error};
+#[cfg(feature = "c-secp256k1")]
 use secp256k1::key::{PublicKey, SecretKey};
+#[cfg(feature = "rust-secp256k1")]
+use secp256k1::{self, PublicKey, SecretKey, Error};
 use bigint::{H256, Address};
 use sha3::{Digest, Keccak256};
 
@@ -9,14 +13,29 @@ pub trait FromKey: Sized {
 }
 
 impl FromKey for Address {
+    #[cfg(feature = "c-secp256k1")]
     fn from_public_key(key: &PublicKey) -> Self {
         let hash = H256::from(
             Keccak256::digest(&key.serialize_vec(&SECP256K1, false)[1..]).as_slice());
         Address::from(hash)
     }
 
+    #[cfg(feature = "rust-secp256k1")]
+    fn from_public_key(key: &PublicKey) -> Self {
+        let hash = H256::from(
+            Keccak256::digest(&key.serialize()[1..]).as_slice());
+        Address::from(hash)
+    }
+
+    #[cfg(feature = "c-secp256k1")]
     fn from_secret_key(key: &SecretKey) -> Result<Self, Error> {
         let public_key = PublicKey::from_secret_key(&SECP256K1, key)?;
+        Ok(Self::from_public_key(&public_key))
+    }
+
+    #[cfg(feature = "rust-secp256k1")]
+    fn from_secret_key(key: &SecretKey) -> Result<Self, Error> {
+        let public_key = PublicKey::from_secret_key(key);
         Ok(Self::from_public_key(&public_key))
     }
 }


### PR DESCRIPTION
Support the pure Rust secp256k1 implementation but still use the C version by default as of now.