### PR TITLE
Supportive functions for new trie implementation

### DIFF
--- a/trie/src/ops/build.rs
+++ b/trie/src/ops/build.rs
@@ -1,0 +1,76 @@
+use merkle::{MerkleValue, MerkleNode};
+use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
+use {Change, DatabaseHandle};
+
+use std::collections::HashMap;
+
+use rlp::{self, Rlp};
+
+fn make_submap<'a, 'b: 'a, T: Iterator<Item=(&'a NibbleVec, &'a &'b [u8])>>(
+    common_len: usize, map: T
+) -> HashMap<NibbleVec, &'b [u8]> {
+    let mut submap = HashMap::new();
+    for (key, value) in map {
+        submap.insert(key[common_len..].into(), value.clone());
+    }
+    submap
+}
+
+pub fn build_value<'a>(node: MerkleNode<'a>) -> (MerkleValue<'a>, Change) {
+    let mut change = Change::default();
+    let value = change.add_value(&node);
+
+    (value, change)
+}
+
+pub fn build_node<'a>(map: &HashMap<NibbleVec, &'a [u8]>) -> (MerkleNode<'a>, Change) {
+    let mut change = Change::default();
+
+    assert!(map.len() > 0);
+    if map.len() == 1 {
+        let key = map.keys().next().unwrap();
+        return (MerkleNode::Leaf(key.clone(), map.get(key).unwrap().clone()), change);
+    }
+
+    debug_assert!(map.len() > 1);
+    let common = nibble::common_all(map.keys().map(|v| v.as_ref()));
+
+    if common.len() > 0 {
+        let submap = make_submap(common.len(), map.iter());
+        debug_assert!(submap.len() > 0);
+
+        let (node, subchange) = build_node(&submap);
+        change.merge(&subchange);
+
+        let (value, subchange) = build_value(node);
+        change.merge(&subchange);
+
+        (MerkleNode::Extension(common.into(), value), change)
+    } else {
+        let mut nodes = empty_nodes!();
+
+        for i in 0..16 {
+            let nibble: Nibble = i.into();
+
+            let submap = make_submap(1, map.iter().filter(|&(key, _value)| {
+                key.len() > 0 && key[0] == nibble
+            }));
+
+            if submap.len() > 0 {
+                let (node, subchange) = build_node(&submap);
+                change.merge(&subchange);
+
+                let (value, subchange) = build_value(node);
+                change.merge(&subchange);
+
+                nodes[i] = value;
+            }
+        }
+
+        let additional = map.iter()
+            .filter(|&(key, _value)| key.len() == 0).next()
+            .map(|(_key, value)| value.clone());
+
+        (MerkleNode::Branch(nodes, additional), change)
+    }
+}

--- a/trie/src/ops/delete.rs
+++ b/trie/src/ops/delete.rs
@@ -22,8 +22,8 @@ fn find_and_remove_child<'a, D: DatabaseHandle>(
     (node, change)
 }
 
-fn collapse_extension<'a, D: DatabaseHandle>(
-    node_nibble: NibbleVec, subnode: MerkleNode<'a>, database: &'a D
+fn collapse_extension<'a>(
+    node_nibble: NibbleVec, subnode: MerkleNode<'a>
 ) -> (MerkleNode<'a>, Change) {
     let mut change = Change::default();
 
@@ -157,7 +157,7 @@ pub fn delete_by_node<'a, D: DatabaseHandle>(
 
                 match subnode {
                     Some(subnode) => {
-                        let (new, subchange) = collapse_extension(node_nibble, subnode, database);
+                        let (new, subchange) = collapse_extension(node_nibble, subnode);
                         change.merge(&subchange);
 
                         Some(new)

--- a/trie/src/ops/get.rs
+++ b/trie/src/ops/get.rs
@@ -1,0 +1,49 @@
+use merkle::{MerkleValue, MerkleNode};
+use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
+use {Change, DatabaseHandle};
+
+use rlp::{self, Rlp};
+
+pub fn get_by_value<'a, D: DatabaseHandle>(
+    merkle: MerkleValue<'a>, nibble: NibbleVec, database: &'a D
+) -> Option<&'a [u8]> {
+    match merkle {
+        MerkleValue::Empty => None,
+        MerkleValue::Full(subnode) => {
+            get_by_node(subnode.as_ref().clone(), nibble, database)
+        },
+        MerkleValue::Hash(h) => {
+            let subnode = MerkleNode::decode(&Rlp::new(database.get(h)));
+            get_by_node(subnode, nibble, database)
+        },
+    }
+}
+
+pub fn get_by_node<'a, D: DatabaseHandle>(
+    node: MerkleNode<'a>, nibble: NibbleVec, database: &'a D
+) -> Option<&'a [u8]> {
+    match node {
+        MerkleNode::Leaf(node_nibble, node_value) => {
+            if node_nibble == nibble {
+                Some(node_value)
+            } else {
+                None
+            }
+        },
+        MerkleNode::Extension(node_nibble, node_value) => {
+            if nibble.starts_with(&node_nibble) {
+                get_by_value(node_value, nibble[node_nibble.len()..].into(), database)
+            } else {
+                None
+            }
+        },
+        MerkleNode::Branch(node_nodes, node_additional) => {
+            if nibble.len() == 0 {
+                node_additional
+            } else {
+                let ni: usize = nibble[0].into();
+                get_by_value(node_nodes[ni].clone(), nibble[1..].into(), database)
+            }
+        },
+    }
+}

--- a/trie/src/ops/mod.rs
+++ b/trie/src/ops/mod.rs
@@ -1,2 +1,4 @@
 pub mod insert;
 pub mod delete;
+pub mod build;
+pub mod get;


### PR DESCRIPTION
Summary:
Implement several supportive function for trie, allowing normal operations.

- Add building support
- Remove Trie struct and use fns directly for simplicity
- Fix compiler warnings
- Add testing for building
- Add merkle getters
- Implement toplevel getters
- Add testing for get
- Use hashmap/hashset for Change implementation

Test Plan: None