### PR TITLE
Init rocksdb adaptor for trie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
   "./block",
   "./block-core",
   "./trie",
+  "./trie/rocksdb",
   "./bloom",
 ]

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,6 @@ in with pkgs;
 stdenv.mkDerivation {
   name = "sputnikvm-env";
   buildInputs = [
-    rustc cargo gdb
+    rustc cargo gdb gcc pkgconfig
   ];
 }

--- a/trie/rocksdb/Cargo.toml
+++ b/trie/rocksdb/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "etcommon-trie-rocksdb"
+version = "0.4.0"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+description = "Rocksdb adaptor for trie."
+repository = "https://github.com/ethereumproject/etcommon-rs"
+keywords = ["ethereum"]
+
+[lib]
+name = "trie_rocksdb"
+
+[dependencies]
+etcommon-trie = { version = "0.4", path = ".." }
+etcommon-bigint = { version = "0.2", path = "../../bigint" }
+rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }

--- a/trie/src/cache.rs
+++ b/trie/src/cache.rs
@@ -1,0 +1,41 @@
+use super::merkle::MerkleNode;
+use bigint::H256;
+use rlp::Rlp;
+use std::collections::HashMap;
+use std::cell::{RefCell, UnsafeCell};
+
+pub struct Cache {
+    cache: UnsafeCell<Vec<Vec<u8>>>,
+    map: RefCell<HashMap<H256, usize>>,
+}
+
+impl Cache {
+    pub fn new() -> Cache {
+        Cache {
+            cache: UnsafeCell::new(Vec::new()),
+            map: RefCell::new(HashMap::new())
+        }
+    }
+
+    pub fn insert<'a>(&'a self, key: H256, value: Vec<u8>) -> &'a [u8] {
+        let cache = unsafe { &mut *self.cache.get() };
+        let index = cache.len();
+        self.map.borrow_mut().insert(key, index);
+        cache.push(value);
+        &cache[index]
+    }
+
+    pub fn get<'a>(&'a self, key: H256) -> Option<&'a [u8]> {
+        let cache = unsafe { &mut *self.cache.get() };
+        let mut map = self.map.borrow_mut();
+        match map.get(&key) {
+            Some(index) => Some(&cache[*index]),
+            None => None,
+        }
+    }
+
+    pub fn contains_key(&self, key: H256) -> bool {
+        let mut map = self.map.borrow_mut();
+        map.contains_key(&key)
+    }
+}

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -39,11 +39,41 @@ pub mod merkle;
 mod ops;
 mod memory;
 mod mutable;
+mod cache;
 
 use ops::{insert, delete, build, get};
+use cache::Cache;
 
 pub use memory::*;
 pub use mutable::*;
+
+pub trait CachedDatabaseHandle {
+    fn get(&self, key: H256) -> Vec<u8>;
+}
+
+pub struct CachedHandle<D: CachedDatabaseHandle> {
+    db: D,
+    cache: Cache,
+}
+
+impl<D: CachedDatabaseHandle> CachedHandle<D> {
+    pub fn new(db: D) -> Self {
+        Self {
+            db,
+            cache: Cache::new(),
+        }
+    }
+}
+
+impl<D: CachedDatabaseHandle> DatabaseHandle for CachedHandle<D> {
+    fn get(&self, key: H256) -> &[u8] {
+        if !self.cache.contains_key(key) {
+            self.cache.insert(key, self.db.get(key))
+        } else {
+            self.cache.get(key).unwrap()
+        }
+    }
+}
 
 /// An immutable database handle.
 pub trait DatabaseHandle {


### PR DESCRIPTION
Summary:
A rocksdb adaptor for trie:
- Cache handler if it returns Vec<u8>.
- Rocksdb interface to TrieMut that allows building tries in-memory before writing it on-disk.