### PR TITLE
Support partial trie fetching and move mutable to trie-memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
   "./block-core",
   "./trie",
   "./trie/rocksdb",
+  "./trie/memory",
   "./bloom",
 ]

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -16,6 +16,7 @@ etcommon-bigint = { version = "0.2", path = "../bigint" }
 etcommon-rlp = { version = "0.2", path = "../rlp" }
 etcommon-bloom = { version = "0.2", path = "../bloom" }
 etcommon-trie = { version = "0.4", path = "../trie" }
+etcommon-trie-memory = { version = "0.4", path = "../trie/memory" }
 blockchain = "0.2"
 
 secp256k1-plus = { version = "0.5", optional = true }

--- a/block/src/block.rs
+++ b/block/src/block.rs
@@ -1,7 +1,7 @@
 use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 use bigint::{Address, Gas, H256, U256, B256, H64, H2048};
 use bloom::LogsBloom;
-use trie::FixedMemoryTrieMut;
+use trie_memory::FixedMemoryTrieMut;
 use sha3::{Keccak256, Digest};
 use std::collections::HashMap;
 use super::{Header, Transaction, Receipt, SignaturePatch};

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -5,6 +5,7 @@ extern crate secp256k1;
 extern crate sha3;
 extern crate blockchain;
 extern crate trie;
+extern crate trie_memory;
 extern crate block_core;
 #[cfg(test)] extern crate hexutil;
 #[cfg(test)] extern crate rand;

--- a/block/tests/genesis.rs
+++ b/block/tests/genesis.rs
@@ -5,13 +5,14 @@ extern crate serde;
 extern crate serde_json;
 extern crate bigint;
 extern crate trie;
+extern crate trie_memory;
 extern crate block;
 extern crate sha3;
 extern crate rlp;
 extern crate rand;
 
 use bigint::{Address, H256, M256, U256};
-use trie::{FixedSecureMemoryTrieMut, MemoryTrieMut, TrieMut};
+use trie_memory::{FixedSecureMemoryTrieMut, MemoryTrieMut, TrieMut};
 use block::Account;
 use sha3::{Digest, Keccak256};
 use rand::Rng;

--- a/trie/memory/Cargo.toml
+++ b/trie/memory/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "etcommon-trie-memory"
+version = "0.4.0"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+description = "Rocksdb adaptor for trie."
+repository = "https://github.com/ethereumproject/etcommon-rs"
+keywords = ["ethereum"]
+
+[lib]
+name = "trie_memory"
+
+[dependencies]
+etcommon-trie = { version = "0.4", path = ".." }
+etcommon-bigint = { version = "0.2", path = "../../bigint" }
+etcommon-rlp = { version = "0.2", path = "../../rlp" }
+sha3 = "0.6"
+
+[dev-dependencies]
+etcommon-hexutil = { version = "0.2", path = "../../hexutil" }

--- a/trie/memory/src/cache.rs
+++ b/trie/memory/src/cache.rs
@@ -1,35 +1,102 @@
 use trie::merkle::MerkleNode;
 use bigint::H256;
 use rlp::Rlp;
+use std::ptr;
 use std::collections::HashMap;
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::{RefCell, Cell};
 
 pub struct Cache {
-    cache: UnsafeCell<Vec<Vec<u8>>>,
     map: RefCell<HashMap<H256, usize>>,
+
+    cache_head: Cell<*mut Node>,
+    cache_len: Cell<usize>,
+}
+
+struct Node {
+    next: *mut Node,
+    value: Vec<u8>,
+}
+
+impl Drop for Cache {
+    fn drop(&mut self) {
+        if self.cache_head.get().is_null() {
+            return;
+        }
+
+        let mut all_ptrs = Vec::new();
+        all_ptrs.push(self.cache_head.get());
+
+        let mut cur_node = unsafe { &*self.cache_head.get() };
+
+        loop {
+            if cur_node.next.is_null() {
+                break;
+            }
+
+            all_ptrs.push(cur_node.next);
+            cur_node = unsafe { &*cur_node.next };
+        }
+
+        for ptr in all_ptrs {
+            unsafe { Box::from_raw(ptr); }
+        }
+    }
 }
 
 impl Cache {
+    fn at<'a>(&'a self, index: usize) -> Option<&'a [u8]> {
+        if self.cache_head.get().is_null() {
+            return None;
+        }
+
+        let mut cur_index = self.cache_len.get() - 1;
+        let mut cur_node = unsafe { &*self.cache_head.get() };
+
+        loop {
+            if cur_index < index {
+                return None;
+            }
+
+            if cur_index == index {
+                return Some(cur_node.value.as_ref());
+            }
+
+            if cur_node.next.is_null() {
+                return None;
+            }
+
+            cur_index -= 1;
+            cur_node = unsafe { &*cur_node.next };
+        }
+    }
+
     pub fn new() -> Cache {
         Cache {
-            cache: UnsafeCell::new(Vec::new()),
-            map: RefCell::new(HashMap::new())
+            map: RefCell::new(HashMap::new()),
+
+            cache_head: Cell::new(ptr::null_mut()),
+            cache_len: Cell::new(0),
         }
     }
 
     pub fn insert<'a>(&'a self, key: H256, value: Vec<u8>) -> &'a [u8] {
-        let cache = unsafe { &mut *self.cache.get() };
-        let index = cache.len();
+        let index = self.cache_len.get();
+        self.cache_len.set(self.cache_len.get() + 1);
+
         self.map.borrow_mut().insert(key, index);
-        cache.push(value);
-        &cache[index]
+        let node_ptr = Box::into_raw(Box::new(Node {
+            next: self.cache_head.get(),
+            value: value,
+        }));
+        self.cache_head.set(node_ptr);
+
+        self.at(index).unwrap()
     }
 
     pub fn get<'a>(&'a self, key: H256) -> Option<&'a [u8]> {
-        let cache = unsafe { &mut *self.cache.get() };
         let mut map = self.map.borrow_mut();
         match map.get(&key) {
-            Some(index) => Some(&cache[*index]),
+            Some(index) => Some(self.at(*index).unwrap()),
             None => None,
         }
     }

--- a/trie/memory/src/cache.rs
+++ b/trie/memory/src/cache.rs
@@ -1,4 +1,4 @@
-use super::merkle::MerkleNode;
+use trie::merkle::MerkleNode;
 use bigint::H256;
 use rlp::Rlp;
 use std::collections::HashMap;

--- a/trie/memory/src/lib.rs
+++ b/trie/memory/src/lib.rs
@@ -1,0 +1,46 @@
+extern crate bigint;
+#[macro_use]
+extern crate trie;
+extern crate rlp;
+extern crate sha3;
+#[cfg(test)] extern crate hexutil;
+
+pub mod gc;
+mod memory;
+mod mutable;
+mod cache;
+
+use cache::Cache;
+use bigint::H256;
+use trie::DatabaseHandle;
+
+pub use memory::*;
+pub use mutable::*;
+
+pub trait CachedDatabaseHandle {
+    fn get(&self, key: H256) -> Vec<u8>;
+}
+
+pub struct CachedHandle<D: CachedDatabaseHandle> {
+    db: D,
+    cache: Cache,
+}
+
+impl<D: CachedDatabaseHandle> CachedHandle<D> {
+    pub fn new(db: D) -> Self {
+        Self {
+            db,
+            cache: Cache::new(),
+        }
+    }
+}
+
+impl<D: CachedDatabaseHandle> DatabaseHandle for CachedHandle<D> {
+    fn get(&self, key: H256) -> Option<&[u8]> {
+        if !self.cache.contains_key(key) {
+            Some(self.cache.insert(key, self.db.get(key)))
+        } else {
+            Some(self.cache.get(key).unwrap())
+        }
+    }
+}

--- a/trie/memory/src/memory.rs
+++ b/trie/memory/src/memory.rs
@@ -1,15 +1,9 @@
 use bigint::H256;
-use {DatabaseHandle, Change, insert, delete, build, get,
-     TrieMut, FixedTrieMut, FixedSecureTrieMut,
+use trie::{DatabaseHandle, Change, insert, delete, build, get};
+use {TrieMut, FixedTrieMut, FixedSecureTrieMut,
      AnyTrieMut, AnySecureTrieMut, SecureTrieMut};
 
 use std::collections::HashMap;
-
-impl<'a> DatabaseHandle for &'a HashMap<H256, Vec<u8>> {
-    fn get(&self, hash: H256) -> &[u8] {
-        HashMap::get(self, &hash).unwrap()
-    }
-}
 
 /// A memory-backed trie.
 #[derive(Clone, Debug)]
@@ -54,21 +48,21 @@ impl TrieMut for MemoryTrieMut {
     }
 
     fn insert(&mut self, key: &[u8], value: &[u8]) {
-        let (new_root, change) = insert(self.root, &&self.database, key, value);
+        let (new_root, change) = insert(self.root, &&self.database, key, value).unwrap();
 
         self.apply_change(change);
         self.root = new_root;
     }
 
     fn delete(&mut self, key: &[u8]) {
-        let (new_root, change) = delete(self.root, &&self.database, key);
+        let (new_root, change) = delete(self.root, &&self.database, key).unwrap();
 
         self.apply_change(change);
         self.root = new_root;
     }
 
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        get(self.root, &&self.database, key).map(|v| v.into())
+        get(self.root, &&self.database, key).unwrap().map(|v| v.into())
     }
 }
 
@@ -99,7 +93,7 @@ impl MemoryTrieMut {
 mod tests {
     use {TrieMut};
     use super::MemoryTrieMut;
-    use merkle::MerkleNode;
+    use trie::merkle::MerkleNode;
     use rlp::Rlp;
 
     use std::collections::HashMap;

--- a/trie/memory/src/memory.rs
+++ b/trie/memory/src/memory.rs
@@ -1,5 +1,5 @@
 use bigint::H256;
-use trie::{DatabaseHandle, Change, insert, delete, build, get};
+use trie::{DatabaseHandle, Change, insert, delete, build, get, EMPTY_TRIE_HASH};
 use {TrieMut, FixedTrieMut, FixedSecureTrieMut,
      AnyTrieMut, AnySecureTrieMut, SecureTrieMut};
 
@@ -31,7 +31,7 @@ impl Default for MemoryTrieMut {
     fn default() -> Self {
         Self {
             database: HashMap::new(),
-            root: empty_trie_hash!(),
+            root: EMPTY_TRIE_HASH,
         }
     }
 }
@@ -93,6 +93,7 @@ impl MemoryTrieMut {
 mod tests {
     use {TrieMut};
     use super::MemoryTrieMut;
+    use trie::EMPTY_TRIE_HASH;
     use trie::merkle::MerkleNode;
     use rlp::Rlp;
 
@@ -134,7 +135,7 @@ mod tests {
         }
 
         assert!(mtrie.database.len() == 0);
-        assert!(mtrie.root == empty_trie_hash!());
+        assert!(mtrie.root == EMPTY_TRIE_HASH);
     }
 
     #[test]

--- a/trie/memory/src/mutable.rs
+++ b/trie/memory/src/mutable.rs
@@ -1,6 +1,6 @@
 use bigint::H256;
-use rlp::{self, Rlp};
 use sha3::{Digest, Keccak256};
+use rlp::{self, Rlp};
 
 use std::marker::PhantomData;
 

--- a/trie/rocksdb/Cargo.toml
+++ b/trie/rocksdb/Cargo.toml
@@ -13,4 +13,5 @@ name = "trie_rocksdb"
 [dependencies]
 etcommon-trie = { version = "0.4", path = ".." }
 etcommon-bigint = { version = "0.2", path = "../../bigint" }
+etcommon-trie-memory = { version = "0.4", path = "../memory" }
 rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }

--- a/trie/src/error.rs
+++ b/trie/src/error.rs
@@ -1,0 +1,6 @@
+use bigint::H256;
+
+#[derive(Debug)]
+pub enum Error {
+    Require(H256),
+}

--- a/trie/src/lib.rs
+++ b/trie/src/lib.rs
@@ -1,5 +1,10 @@
 //! Merkle trie implementation for Ethereum.
 
+#![deny(unused_import_braces, unused_imports,
+        unused_comparisons, unused_must_use,
+        unused_variables, non_shorthand_field_patterns,
+        unreachable_code)]
+
 extern crate bigint;
 extern crate rlp;
 extern crate sha3;
@@ -9,8 +14,7 @@ use bigint::H256;
 use rlp::Rlp;
 use sha3::{Digest, Keccak256};
 use std::collections::{HashMap, HashSet};
-use merkle::{MerkleValue, MerkleNode};
-use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
+use merkle::{MerkleValue, MerkleNode, nibble};
 
 macro_rules! empty_nodes {
     () => (
@@ -25,6 +29,7 @@ macro_rules! empty_nodes {
     )
 }
 
+#[macro_export]
 macro_rules! empty_trie_hash {
     () => {
         {
@@ -36,50 +41,29 @@ macro_rules! empty_trie_hash {
 }
 
 pub mod merkle;
-pub mod gc;
 mod ops;
-mod memory;
-mod mutable;
-mod cache;
+mod error;
 
 use ops::{insert, delete, build, get};
-use cache::Cache;
-
-pub use memory::*;
-pub use mutable::*;
-
-pub trait CachedDatabaseHandle {
-    fn get(&self, key: H256) -> Vec<u8>;
-}
-
-pub struct CachedHandle<D: CachedDatabaseHandle> {
-    db: D,
-    cache: Cache,
-}
-
-impl<D: CachedDatabaseHandle> CachedHandle<D> {
-    pub fn new(db: D) -> Self {
-        Self {
-            db,
-            cache: Cache::new(),
-        }
-    }
-}
-
-impl<D: CachedDatabaseHandle> DatabaseHandle for CachedHandle<D> {
-    fn get(&self, key: H256) -> &[u8] {
-        if !self.cache.contains_key(key) {
-            self.cache.insert(key, self.db.get(key))
-        } else {
-            self.cache.get(key).unwrap()
-        }
-    }
-}
+pub use error::Error;
 
 /// An immutable database handle.
 pub trait DatabaseHandle {
     /// Get a raw value from the database.
-    fn get<'a>(&'a self, key: H256) -> &'a [u8];
+    fn get<'a>(&'a self, key: H256) -> Option<&'a [u8]>;
+
+    fn get_with_error<'a>(&'a self, key: H256) -> Result<&'a [u8], Error> {
+        match self.get(key) {
+            Some(value) => Ok(value),
+            None => Err(Error::Require(key)),
+        }
+    }
+}
+
+impl<'a> DatabaseHandle for &'a HashMap<H256, Vec<u8>> {
+    fn get(&self, hash: H256) -> Option<&[u8]> {
+        HashMap::get(self, &hash).map(|v| v.as_ref())
+    }
 }
 
 /// Change for a merkle trie operation.
@@ -164,22 +148,22 @@ pub fn empty_trie_hash() -> H256 {
 /// Insert to a merkle trie. Return the new root hash and the changes.
 pub fn insert<D: DatabaseHandle>(
     root: H256, database: &D, key: &[u8], value: &[u8]
-) -> (H256, Change) {
+) -> Result<(H256, Change), Error> {
     let mut change = Change::default();
     let nibble = nibble::from_key(key);
 
     let (new, subchange) = if root == empty_trie_hash!() {
         insert::insert_by_empty(nibble, value)
     } else {
-        let old = MerkleNode::decode(&Rlp::new(database.get(root)));
+        let old = MerkleNode::decode(&Rlp::new(database.get_with_error(root)?));
         change.remove_raw(root);
-        insert::insert_by_node(old, nibble, value, database)
+        insert::insert_by_node(old, nibble, value, database)?
     };
     change.merge(&subchange);
     change.add_node(&new);
 
     let hash = H256::from(Keccak256::digest(&rlp::encode(&new).to_vec()).as_slice());
-    (hash, change)
+    Ok((hash, change))
 }
 
 /// Insert to an empty merkle trie. Return the new root hash and the
@@ -202,16 +186,16 @@ pub fn insert_empty<D: DatabaseHandle>(
 /// changes.
 pub fn delete<D: DatabaseHandle>(
     root: H256, database: &D, key: &[u8]
-) -> (H256, Change) {
+) -> Result<(H256, Change), Error> {
     let mut change = Change::default();
     let nibble = nibble::from_key(key);
 
     let (new, subchange) = if root == empty_trie_hash!() {
-        return (root, change)
+        return Ok((root, change))
     } else {
-        let old = MerkleNode::decode(&Rlp::new(database.get(root)));
+        let old = MerkleNode::decode(&Rlp::new(database.get_with_error(root)?));
         change.remove_raw(root);
-        delete::delete_by_node(old, nibble, database)
+        delete::delete_by_node(old, nibble, database)?
     };
     change.merge(&subchange);
 
@@ -220,10 +204,10 @@ pub fn delete<D: DatabaseHandle>(
             change.add_node(&new);
 
             let hash = H256::from(Keccak256::digest(&rlp::encode(&new).to_vec()).as_slice());
-            (hash, change)
+            Ok((hash, change))
         },
         None => {
-            (empty_trie_hash!(), change)
+            Ok((empty_trie_hash!(), change))
         },
     }
 }
@@ -253,12 +237,12 @@ pub fn build(map: &HashMap<Vec<u8>, Vec<u8>>) -> (H256, Change) {
 /// Get a value given the root hash and the database.
 pub fn get<'a, 'b, D: DatabaseHandle>(
     root: H256, database: &'a D, key: &'b [u8]
-) -> Option<&'a [u8]> {
+) -> Result<Option<&'a [u8]>, Error> {
     if root == empty_trie_hash!() {
-        None
+        Ok(None)
     } else {
         let nibble = nibble::from_key(key);
-        let node = MerkleNode::decode(&Rlp::new(database.get(root)));
+        let node = MerkleNode::decode(&Rlp::new(database.get_with_error(root)?));
         get::get_by_node(node, nibble, database)
     }
 }

--- a/trie/src/merkle/mod.rs
+++ b/trie/src/merkle/mod.rs
@@ -3,5 +3,4 @@
 pub mod nibble;
 mod node;
 
-use self::nibble::{Nibble, NibbleVec, NibbleSlice, NibbleType};
 pub use self::node::{MerkleNode, MerkleValue};

--- a/trie/src/merkle/nibble.rs
+++ b/trie/src/merkle/nibble.rs
@@ -1,10 +1,7 @@
 //! Merkle nibble types.
 
-use rlp::{RlpStream, Encodable, Decodable, Rlp, Prototype};
-use std::ops::Deref;
+use rlp::{RlpStream, Rlp};
 use std::cmp::min;
-use std::hash::{Hash, Hasher};
-use std::fmt::{self, Debug, Formatter};
 
 /// Represents a nibble. A 16-variant value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/trie/src/merkle/node.rs
+++ b/trie/src/merkle/node.rs
@@ -1,6 +1,6 @@
-use super::nibble::{self, Nibble, NibbleVec, NibbleSlice, NibbleType};
+use super::nibble::{self, NibbleVec, NibbleType};
 
-use rlp::{self, RlpStream, Encodable, Decodable, Rlp, Prototype};
+use rlp::{self, RlpStream, Encodable, Rlp, Prototype};
 use bigint::H256;
 use std::borrow::Borrow;
 
@@ -159,8 +159,7 @@ impl<'a> Encodable for MerkleValue<'a> {
 mod tests {
     use hexutil::read_hex;
     use rlp::{self, Rlp};
-    use sha3::{Digest, Keccak256};
-    use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
+    use merkle::nibble;
     use super::MerkleNode;
 
     #[test]

--- a/trie/src/ops/build.rs
+++ b/trie/src/ops/build.rs
@@ -1,10 +1,8 @@
 use merkle::{MerkleValue, MerkleNode};
-use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
-use {Change, DatabaseHandle};
+use merkle::nibble::{self, NibbleVec, Nibble};
+use Change;
 
 use std::collections::HashMap;
-
-use rlp::{self, Rlp};
 
 fn make_submap<'a, 'b: 'a, T: Iterator<Item=(&'a NibbleVec, &'a &'b [u8])>>(
     common_len: usize, map: T

--- a/trie/src/ops/get.rs
+++ b/trie/src/ops/get.rs
@@ -1,19 +1,19 @@
 use merkle::{MerkleValue, MerkleNode};
-use merkle::nibble::{self, NibbleVec, NibbleSlice, Nibble};
-use {Change, DatabaseHandle};
+use merkle::nibble::NibbleVec;
+use {DatabaseHandle, Error};
 
-use rlp::{self, Rlp};
+use rlp::Rlp;
 
 pub fn get_by_value<'a, D: DatabaseHandle>(
     merkle: MerkleValue<'a>, nibble: NibbleVec, database: &'a D
-) -> Option<&'a [u8]> {
+) -> Result<Option<&'a [u8]>, Error> {
     match merkle {
-        MerkleValue::Empty => None,
+        MerkleValue::Empty => Ok(None),
         MerkleValue::Full(subnode) => {
             get_by_node(subnode.as_ref().clone(), nibble, database)
         },
         MerkleValue::Hash(h) => {
-            let subnode = MerkleNode::decode(&Rlp::new(database.get(h)));
+            let subnode = MerkleNode::decode(&Rlp::new(database.get_with_error(h)?));
             get_by_node(subnode, nibble, database)
         },
     }
@@ -21,25 +21,25 @@ pub fn get_by_value<'a, D: DatabaseHandle>(
 
 pub fn get_by_node<'a, D: DatabaseHandle>(
     node: MerkleNode<'a>, nibble: NibbleVec, database: &'a D
-) -> Option<&'a [u8]> {
+) -> Result<Option<&'a [u8]>, Error> {
     match node {
         MerkleNode::Leaf(node_nibble, node_value) => {
             if node_nibble == nibble {
-                Some(node_value)
+                Ok(Some(node_value))
             } else {
-                None
+                Ok(None)
             }
         },
         MerkleNode::Extension(node_nibble, node_value) => {
             if nibble.starts_with(&node_nibble) {
                 get_by_value(node_value, nibble[node_nibble.len()..].into(), database)
             } else {
-                None
+                Ok(None)
             }
         },
         MerkleNode::Branch(node_nodes, node_additional) => {
             if nibble.len() == 0 {
-                node_additional
+                Ok(node_additional)
             } else {
                 let ni: usize = nibble[0].into();
                 get_by_value(node_nodes[ni].clone(), nibble[1..].into(), database)


### PR DESCRIPTION
This implements two things and fixes several tests:

* Support partial trie. DatabaseHandle is changed to allow returning
  Option, and all op fns will return Error::Require(hash) if one of
  the hash is missing in the database. Client can use this information
  to further retrieve the required hash and try again.
* trie now contains a mostly stable interface. Mutable structs
  interface may change a lot, and they're moved to trie-memory crate.