### PR TITLE
Remove blockchain-rs dependency

### DIFF
--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -16,7 +16,6 @@ etcommon-bigint = { version = "0.2", path = "../bigint" }
 etcommon-rlp = { version = "0.2", path = "../rlp" }
 etcommon-bloom = { version = "0.2", path = "../bloom" }
 etcommon-trie = { version = "0.4", path = "../trie" }
-blockchain = "0.2"
 
 secp256k1-plus = { version = "0.5", optional = true }
 libsecp256k1 = { version = "0.1", optional = true }

--- a/block/src/header.rs
+++ b/block/src/header.rs
@@ -2,9 +2,13 @@ use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 use bigint::{Address, Gas, H256, U256, B256, H64};
 use bloom::LogsBloom;
 use std::cmp::Ordering;
-use blockchain::chain::HeaderHash;
 use sha3::{Keccak256, Digest};
 use super::RlpHash;
+
+pub trait HeaderHash<H: Copy> {
+    fn parent_hash(&self) -> Option<H>;
+    fn header_hash(&self) -> H;
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TotalHeader(pub Header, U256);

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -3,7 +3,6 @@ extern crate rlp;
 extern crate bloom;
 extern crate secp256k1;
 extern crate sha3;
-extern crate blockchain;
 extern crate trie;
 extern crate block_core;
 #[cfg(test)] extern crate hexutil;


### PR DESCRIPTION
The original idea is only related to etclient, which tries to find a way to support totally-different block/header structures using the same framework. It apparently didn't go as far as it should be. And so removing the blockchain-rs dependency would be a good choice.