### PR TITLE
no_std support for hexutil and rlp

### DIFF
--- a/bigint/src/hash/mod.rs
+++ b/bigint/src/hash/mod.rs
@@ -12,7 +12,7 @@
 mod rlp;
 
 #[cfg(all(not(feature = "std"), feature = "string"))]
-use alloc::String;
+use alloc::string::String;
 
 #[cfg(feature = "std")] use std::{ops, fmt, cmp};
 #[cfg(feature = "std")] use std::cmp::{min, Ordering};

--- a/bigint/src/uint/mod.rs
+++ b/bigint/src/uint/mod.rs
@@ -40,7 +40,7 @@
 #[cfg(not(feature = "std"))] use core::cmp::Ordering;
 
 #[cfg(all(not(feature = "std"), feature = "string"))]
-use alloc::String;
+use alloc::string::String;
 
 use byteorder::{ByteOrder, BigEndian, LittleEndian};
 #[cfg(feature = "string")]

--- a/block-core/src/log.rs
+++ b/block-core/src/log.rs
@@ -2,7 +2,7 @@ use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
 use bigint::{Address, Gas, H256, U256, B256, H64};
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Log {

--- a/hexutil/Cargo.toml
+++ b/hexutil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-hexutil"
-version = "0.2.3"
+version = "0.2.4"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Hex helper functions."

--- a/hexutil/src/lib.rs
+++ b/hexutil/src/lib.rs
@@ -10,9 +10,9 @@ use std::fmt::Write;
 #[cfg(not(feature = "std"))]
 use core::fmt::Write;
 #[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
-use alloc::string::ToString;
+use alloc::string::{ToString, String};
 
 #[derive(Debug)]
 /// Errors exhibited from `read_hex`.

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -3,7 +3,7 @@ name = "etcommon-rlp"
 description = "Recursive-length prefix encoding, decoding, and compression"
 repository = "https://github.com/ethereumproject/etcommon-rs"
 license = "MIT/Apache-2.0"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Parity Technologies <admin@parity.io>", "Wei Tang <hi@that.world>"]
 keywords = ["no_std"]
 
@@ -11,7 +11,7 @@ keywords = ["no_std"]
 name = "rlp"
 
 [dependencies]
-elastic-array-plus = { version = "0.9.1", default-features = false }
+elastic-array-plus = { version = "0.9.2", default-features = false }
 lazy_static = { version = "0.2", optional = true }
 byteorder = { version = "1.0", default-features = false }
 etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["no_std"]
 name = "rlp"
 
 [dependencies]
-elastic-array-plus = { version = "0.9.2", default-features = false }
+elastic-array-plus = { version = "0.10.0", default-features = false }
 lazy_static = { version = "0.2", optional = true }
 byteorder = { version = "1.0", default-features = false }
 etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }

--- a/rlp/src/compression.rs
+++ b/rlp/src/compression.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 #[cfg(feature = "std")] use std::collections::{HashMap as Map};
-#[cfg(not(feature = "std"))] use alloc::{BTreeMap as Map};
+#[cfg(not(feature = "std"))] use alloc::collections::{BTreeMap as Map};
 use elastic_array::ElasticArray1024;
 #[cfg(feature = "std")]
 use common::{BLOCKS_RLP_SWAPPER, SNAPSHOT_RLP_SWAPPER};

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(not(feature = "std"))]use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]use alloc::string::String;
 
 #[cfg(feature = "std")] use std::{cmp, mem, str};
 #[cfg(not(feature = "std"))] use core::{cmp, mem, str};

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -61,8 +61,8 @@ mod compression;
 mod common;
 mod impls;
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(not(feature = "std"))]use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]use alloc::string::String;
 
 #[cfg(feature = "std")] use std::borrow::Borrow;
 #[cfg(not(feature = "std"))] use core::borrow::Borrow;

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(not(feature = "std"))]use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]use alloc::string::String;
 
 #[cfg(feature = "std")] use std::fmt;
 #[cfg(not(feature = "std"))] use core::fmt;

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(not(feature = "std"))] use alloc::string::String;
+#[cfg(not(feature = "std"))] use alloc::vec::Vec;
 
 #[cfg(feature = "std")] use std::borrow::Borrow;
 #[cfg(not(feature = "std"))] use core::borrow::Borrow;

--- a/rlp/src/untrusted_rlp.rs
+++ b/rlp/src/untrusted_rlp.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "std"))]
-use alloc::{String, Vec};
+#[cfg(not(feature = "std"))]use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]use alloc::string::String;
 
 #[cfg(feature = "std")] use std::cell::Cell;
 #[cfg(feature = "std")] use std::fmt;

--- a/trie/rocksdb/Cargo.toml
+++ b/trie/rocksdb/Cargo.toml
@@ -13,4 +13,4 @@ name = "trie_rocksdb"
 [dependencies]
 etcommon-trie = { version = "0.4", path = ".." }
 etcommon-bigint = { version = "0.2", path = "../../bigint" }
-parity-rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }
+parity-rocksdb = "0.5.0"

--- a/trie/rocksdb/Cargo.toml
+++ b/trie/rocksdb/Cargo.toml
@@ -13,4 +13,4 @@ name = "trie_rocksdb"
 [dependencies]
 etcommon-trie = { version = "0.4", path = ".." }
 etcommon-bigint = { version = "0.2", path = "../../bigint" }
-rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }
+parity-rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }

--- a/trie/rocksdb/src/lib.rs
+++ b/trie/rocksdb/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate trie;
 extern crate bigint;
-extern crate rocksdb;
+extern crate parity_rocksdb as rocksdb;
 
 use bigint::H256;
 use trie::{CachedDatabaseHandle, CachedHandle, Change, DatabaseHandle, TrieMut, get, insert, delete};


### PR DESCRIPTION
Rust removed re-using of structs in the alloc crate.
This fixes it.
I also bumped the version numbers (Can remove these commit if you prefer)