### PR TITLE
Fix TransactionAction to make it Sendable

### DIFF
--- a/block-core/Cargo.toml
+++ b/block-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block-core"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Core block and transaction types for Ethereum."

--- a/block-core/Cargo.toml
+++ b/block-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block-core"
-version = "0.2.1"
+version = "0.3.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Core block and transaction types for Ethereum."

--- a/block-core/src/transaction.rs
+++ b/block-core/src/transaction.rs
@@ -8,7 +8,7 @@ use sha3::{Digest, Keccak256};
 
 // Use transaction action so we can keep most of the common fields
 // without creating a large enum.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TransactionAction {
     Call(Address),
     Create,

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcommon-block"
-version = "0.4.0"
+version = "0.5.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Block and transaction types for Ethereum."
@@ -11,7 +11,7 @@ name = "block"
 
 [dependencies]
 sha3 = "0.6"
-etcommon-block-core = { version = "0.2", path = "../block-core" }
+etcommon-block-core = { version = "0.3", path = "../block-core" }
 etcommon-bigint = { version = "0.2", path = "../bigint" }
 etcommon-rlp = { version = "0.2", path = "../rlp" }
 etcommon-bloom = { version = "0.2", path = "../bloom" }


### PR DESCRIPTION
I messed up a bit with making Create2 TransactionAction accept Rc link to the init code, thus making it `!Send` which consequently interferes with stateful parallel example:
```
error[E0277]: `std::rc::Rc<std::vec::Vec<u8>>` cannot be sent between threads safely
   --> stateful/examples/parallel.rs:185:22
    |
185 |         threads.push(thread::spawn(move || {
    |                      ^^^^^^^^^^^^^ `std::rc::Rc<std::vec::Vec<u8>>` cannot be sent between threads safely
    |
    = help: within `[closure@stateful/examples/parallel.rs:185:36: 190:10 stateful:std::sync::Arc<sputnikvm_stateful::Stateful<'_, trie::MemoryDatabase>>, transaction:SendableValidTransaction, header:sputnikvm::HeaderParams]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<std::vec::Vec<u8>>`
    = note: required because it appears within the type `block::TransactionAction`
    = note: required because it appears within the type `SendableValidTransaction`
    = note: required because it appears within the type `[closure@stateful/examples/parallel.rs:185:36: 190:10 stateful:std::sync::Arc<sputnikvm_stateful::Stateful<'_, trie::MemoryDatabase>>, transaction:SendableValidTransaction, header:sputnikvm::HeaderParams]`
    = note: required by `std::thread::spawn`
```

Fixed it by accepting M256 code_hash which is calculated on SputnikVM side.

So I propose to make a minor version bump and yank the original 0.2.0 from crates.io, while it's not too widespread in the community (it has like 14 downloads so far, most of which are docs.rs and myself, I assume).

Alternatively we can bump the major version again, though that would require us to bump version of `block` too and update version in SputnikVM again.