### PR TITLE
update lazy_static version to 1.4

### DIFF
--- a/block-core/src/account.rs
+++ b/block-core/src/account.rs
@@ -1,5 +1,5 @@
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-use bigint::{Address, Gas, H256, U256, B256};
+use bigint::{H256, U256};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Account {

--- a/block-core/src/log.rs
+++ b/block-core/src/log.rs
@@ -1,5 +1,5 @@
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-use bigint::{Address, Gas, H256, U256, B256, H64};
+use bigint::{Address, H256};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;

--- a/block-core/src/transaction.rs
+++ b/block-core/src/transaction.rs
@@ -4,7 +4,6 @@ use sha3::{Digest, Keccak256};
 
 #[cfg(not(feature = "std"))] use alloc::vec::Vec;
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
-#[cfg(feature = "std")] use std::rc::Rc;
 
 // Use transaction action so we can keep most of the common fields
 // without creating a large enum.
@@ -84,7 +83,7 @@ mod tests {
 
     #[test]
     fn rlp_roundtrip_call() {
-        let address = Address::from(M256::from(0xDEADBEEFDEADBEEFDEADBEEF_u64));
+        let address = Address::from(M256::from(std::u64::MAX));
         let action = TransactionAction::Call(address);
         let encoded = rlp::encode(&action);
         let decoded: TransactionAction = rlp::decode(&encoded);
@@ -101,7 +100,7 @@ mod tests {
 
     #[test]
     fn rlp_roundtrip_create2() {
-        let salt = H256::from(M256::from(0xDEADBEEF));
+        let salt = H256::from(M256::from(std::i32::MAX));
         let code_hash = M256::from(1024);
         let action = TransactionAction::Create2(salt, code_hash);
         let encoded = rlp::encode(&action);

--- a/block/src/block.rs
+++ b/block/src/block.rs
@@ -1,10 +1,8 @@
 use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-use bigint::{Address, Gas, H256, U256, B256, H64, H2048};
-use bloom::LogsBloom;
+use bigint::{H256, U256};
 use trie::FixedMemoryTrieMut;
 use sha3::{Keccak256, Digest};
-use std::collections::HashMap;
-use super::{Header, Transaction, Receipt, SignaturePatch};
+use super::{Header, Transaction, Receipt};
 
 pub fn transactions_root(transactions: &[Transaction]) -> H256 {
     let mut trie = FixedMemoryTrieMut::default();
@@ -70,13 +68,11 @@ impl Decodable for Block {
 
 #[cfg(test)]
 mod tests {
-    use rlp::{encode, decode, Rlp};
+    use rlp::{encode, decode};
     use hexutil::read_hex;
     use bigint::{U256, H256, Address, Gas};
-    use bloom::LogsBloom;
     use block::Block;
     use TransactionAction;
-    use transaction::GlobalSignaturePatch;
     use std::str::FromStr;
 
     #[test]

--- a/block/src/receipt.rs
+++ b/block/src/receipt.rs
@@ -1,5 +1,5 @@
 use rlp::{Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-use bigint::{Address, Gas, H256, U256, B256, H64};
+use bigint::{Gas, H256};
 use bloom::LogsBloom;
 
 use super::Log;

--- a/block/src/transaction.rs
+++ b/block/src/transaction.rs
@@ -1,15 +1,14 @@
 #[cfg(feature = "c-secp256k1")]
 use secp256k1::{Message, Error, RecoverableSignature, RecoveryId, SECP256K1};
 #[cfg(feature = "c-secp256k1")]
-use secp256k1::key::{PublicKey, SecretKey};
+use secp256k1::key::SecretKey;
 #[cfg(feature = "rust-secp256k1")]
 use secp256k1::{self, Message, Error, Signature, RecoveryId, SecretKey, PublicKey};
 
 use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-use bigint::{Address, Gas, H256, U256, B256, M256};
+use bigint::{Address, Gas, H256, U256};
 use sha3::{Digest, Keccak256};
 use address::FromKey;
-use std::marker::PhantomData;
 use std::str::FromStr;
 use super::{TransactionAction, RlpHash};
 
@@ -46,8 +45,6 @@ pub struct HomesteadValidationPatch;
 impl ValidationPatch for HomesteadValidationPatch {
     fn require_low_s() -> bool { true }
 }
-
-const ECDSA_SIGNATURE_BYTES: usize = 65;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionSignature {
@@ -303,14 +300,12 @@ impl RlpHash for Transaction {
 
 #[cfg(test)]
 mod tests {
-    use secp256k1::{Message, Error, RecoverableSignature, RecoveryId, SECP256K1};
-    use secp256k1::key::{PublicKey, SecretKey};
-    use rlp::{self, Encodable, Decodable, RlpStream, DecoderError, UntrustedRlp};
-    use bigint::{Address, Gas, H256, U256, B256};
-    use sha3::{Digest, Keccak256};
+    use secp256k1::SECP256K1;
+    use secp256k1::key::SecretKey;
+    use bigint::{Address, Gas, U256};
     use address::FromKey;
     use rand::os::OsRng;
-    use super::{Transaction, UnsignedTransaction, TransactionAction, ClassicSignaturePatch,
+    use super::{UnsignedTransaction, TransactionAction, ClassicSignaturePatch,
                 HomesteadValidationPatch};
 
     #[test]

--- a/block/tests/genesis.rs
+++ b/block/tests/genesis.rs
@@ -41,7 +41,7 @@ pub fn test_genesis_root() {
     let genesis_accounts: HashMap<String, JSONAccount> =
         serde_json::from_str(include_str!("../res/genesis.json")).unwrap();
 
-    let mut accounts: Vec<(&String, &JSONAccount)> = genesis_accounts.iter().collect();
+    let accounts: Vec<(&String, &JSONAccount)> = genesis_accounts.iter().collect();
     let mut account_trie: FixedSecureMemoryTrieMut<Address, Account> = Default::default();
     let mut account_db: HashMap<Address, Account> = HashMap::new();
     let mut addresses: Vec<Address> = Vec::new();

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -12,7 +12,7 @@ name = "rlp"
 
 [dependencies]
 elastic-array-plus = { version = "0.10.0", default-features = false }
-lazy_static = { version = "0.2", optional = true }
+lazy_static = { version = "1.4", optional = true }
 byteorder = { version = "1.0", default-features = false }
 etcommon-hexutil = { version = "0.2", path = "../hexutil", default-features = false }
 


### PR DESCRIPTION
My project uses rlp and the old version of lazy_static leads to multiple versions of lazy_static be compiled when the project is build.
Please update to the 1.4 version